### PR TITLE
add public visibility to the client_python target

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -45,7 +45,8 @@ py_library(
         requirement("grpcio"),
         requirement("six"),
         requirement("enum34"),
-    ]
+    ],
+    visibility =["//visibility:public"]
 )
 
 deploy_pip(


### PR DESCRIPTION
target `client_python` should be and now is accessible by anyone.