### PR TITLE
Sync with changes in Grakn gRPC protocol

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "graknlabs_grakn_core",
     remote = "https://github.com/graknlabs/grakn",
-    commit = "87b47f6d1f494f9a7de6f39356cce6f26d5cc401"
+    commit = "80a9d8f01cb2fe642b9c29d0c550987dee3feb67"
 )
 
 git_repository(

--- a/grakn/service/Session/TransactionService.py
+++ b/grakn/service/Session/TransactionService.py
@@ -28,15 +28,15 @@ from grakn.exception.GraknError import GraknError
 
 class TransactionService(object):
 
-    def __init__(self, keyspace, tx_type, credentials, transaction_endpoint):
-        self.keyspace = keyspace
+    def __init__(self, session_id, tx_type, credentials, transaction_endpoint):
+        self.session_id = session_id
         self.tx_type = tx_type.value
         self.credentials = credentials
 
         self._communicator = Communicator(transaction_endpoint)
 
         # open the transaction with an 'open' message
-        open_req = RequestBuilder.open_tx(keyspace, tx_type, credentials)
+        open_req = RequestBuilder.open_tx(session_id, tx_type, credentials)
         self._communicator.send(open_req)
     __init__.__annotations__ = {'tx_type': enums.TxType}
 

--- a/grakn/service/Session/util/RequestBuilder.py
+++ b/grakn/service/Session/util/RequestBuilder.py
@@ -40,9 +40,9 @@ class RequestBuilder(object):
 
     # --- Top level functionality ---
     @staticmethod
-    def open_tx(keyspace, tx_type, credentials):
+    def open_tx(session_id, tx_type, credentials):
         open_request = transaction_messages.Transaction.Open.Req()
-        open_request.keyspace = keyspace
+        open_request.sessionId = session_id
         open_request.type = tx_type.value
         if credentials is not None:
             open_request.username = credentials['username']
@@ -51,6 +51,18 @@ class RequestBuilder(object):
         transaction_req = transaction_messages.Transaction.Req()
         transaction_req.open_req.CopyFrom(open_request)
         return transaction_req
+
+    @staticmethod
+    def open_session(keyspace):
+        open_session_request = transaction_messages.Session.Open.Req()
+        open_session_request.Keyspace = keyspace
+        return open_session_request
+
+    @staticmethod
+    def close_session(session_id):
+        close_session_request = transaction_messages.Session.Close.Req()
+        close_session_request.sessionId = session_id
+        return close_session_request
 
     @staticmethod
     def query(query, infer=True):


### PR DESCRIPTION
# Why is this PR needed?

So we are able to use `client-python` with the latest `@graknlabs_grakn_core`

# What does the PR do?

- Upgrades commit hash of `@graknlabs_grakn_core` to the same as in `client-nodejs`
- Fixes the client to comply with new API

# Does it break backwards compatibility?

—

# List of future improvements not on this PR

—