### PR TITLE
Automatically deploy master branch to test PyPI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,8 +54,20 @@ jobs:
       - run: nohup bazel-genfiles/dist/grakn-core-all/grakn server start
       - run: bazel test //:test_integration --test_output=streamed
 
+  test-repo-deploy:
+    machine: true
+    working_directory: ~/grakn
+    steps:
+      - checkout
+      - bazel_install
+      - run: bazel run //:deploy-pip -- test $TEST_REPO_USERNAME $TEST_REPO_PASSWORD
+
 workflows:
   version: 2
   grakn-client-python-ci:
     jobs:
       - client-python
+      - test-repo-deploy:
+          filters:
+            branches:
+              only: master

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "graknlabs_grakn_core",
     remote = "https://github.com/graknlabs/grakn",
-    commit = "80a9d8f01cb2fe642b9c29d0c550987dee3feb67"
+    commit = "ec41e803e3a12696cec731ad6071c26e90cea926"
 )
 
 git_repository(
@@ -28,7 +28,7 @@ python_grpc_compile()
 git_repository(
     name="graknlabs_bazel_distribution",
     remote="https://github.com/graknlabs/bazel-distribution",
-    commit="90344d523a7d552dcd35da8931da172490855fac"
+    commit="18d774e16187bd4148fe36842b68bafa46017d6f"
 )
 
 pip_import(


### PR DESCRIPTION
## What is the goal of this PR?

Fixes #12

`master` branch of `client-python` will be automatically deployed to test PyPI at [repo.grakn.ai](http://repo.grakn.ai); configured [here](https://github.com/graknlabs/grakn/blob/ec41e803e3a12696cec731ad6071c26e90cea926/deployment.properties#L25)

## What are the changes implemented in this PR?

- Added invocation of `//:deploy-pip` `bazel` target on `master` branch
