### PR TITLE
Deployment in CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,27 @@ jobs:
       - bazel_install
       - run: bazel run //:deploy-pip -- test $TEST_REPO_USERNAME $TEST_REPO_PASSWORD
 
+  approve-release:
+    machine: true
+    steps:
+      - checkout
+      - run: bazel run @graknlabs_grabl//sync:approve-release
+
+  deploy-pypi:
+    machine: true
+    working_directory: ~/grakn
+    steps:
+      - checkout
+      - bazel_install
+      - bazel_add_rbe_credential
+      - run: bazel run //:deploy-pip -- pypi $PYPI_REPO_USERNAME $PYPI_REPO_PASSWORD
+
+  release-cleanup:
+    machine: true
+    steps:
+      - checkout
+      - run: git push --delete origin grakn-client-python-release-branch
+
 workflows:
   version: 2
   grakn-client-python-ci:
@@ -71,3 +92,28 @@ workflows:
           filters:
             branches:
               only: master
+          requires:
+            - client-python
+      - approve-release:
+          filters:
+            branches:
+              only: master
+          requires:
+            - client-python
+
+  # the 'grakn-client-python-release' workflow is triggered by the creation of 'grakn-client-python-release-branch' branch in graknlabs/grakn
+  # it consists of jobs which:
+  # - publishes client-python to PyPI
+  # - cleans up the 'grakn-client-python-release-branch' branch which was created by the approve-release job
+  grakn-client-python-release:
+    jobs:
+      - deploy-pypi:
+          filters:
+            branches:
+              only: grakn-client-python-release-branch
+      - release-cleanup:
+          requires:
+            - deploy-pypi
+          filters:
+            branches:
+              only: grakn-client-python-release-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: bazel run @graknlabs_grabl//sync:approve-release
+      - run: bazel run @graknlabs_grabl//ci:approve-release
 
   deploy-pypi:
     machine: true

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,6 +26,12 @@ python_grpc_compile()
 
 
 git_repository(
+    name = "graknlabs_grabl",
+    remote = "https://github.com/graknlabs/grabl",
+    commit = "87d2cd9256f16fb85a39514c881cdb1b6632f344",
+)
+
+git_repository(
     name="graknlabs_bazel_distribution",
     remote="https://github.com/graknlabs/bazel-distribution",
     commit="6298bcf46c0ae8b1b5c9bd5138e10be38a3a9bc3"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,7 +28,7 @@ python_grpc_compile()
 git_repository(
     name = "graknlabs_grabl",
     remote = "https://github.com/graknlabs/grabl",
-    commit = "87d2cd9256f16fb85a39514c881cdb1b6632f344",
+    commit = "5294d9831fec8e246e73f6afb5f7bcd9cd8364da",
 )
 
 git_repository(


### PR DESCRIPTION
## What is the goal of this PR?

Allows to deploy `client-python` to PyPI after approval
Fixes #5

## What are the changes implemented in this PR?

- add a reference to `@graknlabs_grabl` so `approve-release` is available as `bazel` target
- `test-repo-deploy` now depends on tests successfully passing
- added `approve-release`/`deploy-pypi`/`release-cleanup` jobs