### PR TITLE
Update usage of CI scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,11 +62,12 @@ jobs:
       - bazel_install
       - run: bazel run //:deploy-pip -- test $TEST_REPO_USERNAME $TEST_REPO_PASSWORD
 
-  approve-release:
+  release-approval:
     machine: true
     steps:
       - checkout
-      - run: bazel run @graknlabs_grabl//ci:approve-release
+      - bazel_install
+      - run: bazel run @graknlabs_grabl//ci:release-approval
 
   deploy-pypi:
     machine: true
@@ -94,7 +95,7 @@ workflows:
               only: master
           requires:
             - client-python
-      - approve-release:
+      - release-approval:
           filters:
             branches:
               only: master
@@ -104,7 +105,7 @@ workflows:
   # the 'grakn-client-python-release' workflow is triggered by the creation of 'grakn-client-python-release-branch' branch in graknlabs/grakn
   # it consists of jobs which:
   # - publishes client-python to PyPI
-  # - cleans up the 'grakn-client-python-release-branch' branch which was created by the approve-release job
+  # - cleans up the 'grakn-client-python-release-branch' branch which was created by the release-approval job
   grakn-client-python-release:
     jobs:
       - deploy-pypi:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,7 +28,7 @@ python_grpc_compile()
 git_repository(
     name = "graknlabs_grabl",
     remote = "https://github.com/graknlabs/grabl",
-    commit = "5294d9831fec8e246e73f6afb5f7bcd9cd8364da",
+    commit = "ad79f87f869d25694fe11196e16be42a80e95d14",
 )
 
 git_repository(


### PR DESCRIPTION
## What is the goal of this PR?

Use the latest CI helper scripts

## What are the changes implemented in this PR?

- Bump `@graknlabs_grabl` version
- Adapt to newest naming in scripts
- Rename `approve-release` -> `release-approval` CI job
- Install missing `bazel` on `release-approval` stage