### PR TITLE
add dependency update to client-python ci workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,17 @@ jobs:
       - bazel_install
       - run: bazel run //:deploy-pip -- test $TEST_REPO_USERNAME $TEST_REPO_PASSWORD
 
+  dependency-update:
+    machine: true
+    steps:
+      - checkout
+      - bazel_install
+      - run:
+          name: Sync docs:development dependency to the latest Grakn Client Python version
+          command: |
+            bazel run @graknlabs_grabl//sync:dependency-update -- --dependency client-python:master \
+              --user docs:development
+
   release-approval:
     machine: true
     steps:
@@ -101,6 +112,13 @@ workflows:
       - build
       - test
       - test-repo-deploy:
+          filters:
+            branches:
+              only: master
+          requires:
+            - build
+            - test
+      - dependency-update:
           filters:
             branches:
               only: master


### PR DESCRIPTION
## What is the goal of this PR?
to ensure that every commit to `client-python/master`, updates the `doc/development`'s `client-python` dependency to the latest commit of `client-python/master`.

## What are the changes implemented in this PR?
- reuse Grakn's `dependency-update` job that uses Grabl's dependency-update to update `client-python` dependency inside `WORKSPACE` of `docs/development`.
- include `dependency-update` job in the `client-python` workflow requiring `build` and `test`. 
