### PR TITLE
removes the test-repo-deploy job from workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,14 +64,6 @@ jobs:
       - run: nohup bazel-genfiles/dist/grakn-core-all/grakn server start
       - run: bazel test //:test_integration --test_output=streamed
 
-  test-repo-deploy:
-    machine: true
-    working_directory: ~/grakn
-    steps:
-      - checkout
-      - bazel_install
-      - run: bazel run //:deploy-pip -- test $TEST_REPO_USERNAME $TEST_REPO_PASSWORD
-
   dependency-update:
     machine: true
     steps:
@@ -111,13 +103,6 @@ workflows:
     jobs:
       - build
       - test
-      - test-repo-deploy:
-          filters:
-            branches:
-              only: master
-          requires:
-            - build
-            - test
       - dependency-update:
           filters:
             branches:


### PR DESCRIPTION
## What is the goal of this PR?

to remove the unnecessary job of deploying client-python as a test-package.

## What are the changes implemented in this PR?

removes the `test-repo-deploy` job from the `client-python` workflow.
