### PR TITLE
Grakn 1.5 synchronization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .ijwb
+.idea
 bazel-*

--- a/grakn/service/Keyspace/KeyspaceService.py
+++ b/grakn/service/Keyspace/KeyspaceService.py
@@ -17,18 +17,14 @@
 # under the License.
 #
 
-import grpc
 from grakn.rpc.protocol.keyspace.Keyspace_pb2_grpc import KeyspaceServiceStub
 import grakn.rpc.protocol.keyspace.Keyspace_pb2 as keyspace_messages
 
 class KeyspaceService(object):
 
-    def __init__(self, uri, credentials):
-
+    def __init__(self, uri, channel):
         self.uri = uri
-        self.credentials = credentials
-        self._channel = grpc.insecure_channel(uri)
-        self.stub = KeyspaceServiceStub(self._channel)
+        self.stub = KeyspaceServiceStub(channel)
 
     def retrieve(self):
         retrieve_request = keyspace_messages.Keyspace.Retrieve.Req()

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -51,3 +51,7 @@ class test_Base(TestCase):
             print 'Patching unittest.TestCase.subTest for PY2'
             curse(datetime, 'timestamp', _datetime_to_timestamp)
             curse(TestCase, 'subTest', DummyContextManager)
+
+    @classmethod
+    def tearDownClass(cls):
+        super(test_Base, cls).tearDownClass()

--- a/tests/integration/test_concept.py
+++ b/tests/integration/test_concept.py
@@ -68,7 +68,6 @@ class test_concept_Base(test_Base):
     @classmethod
     def tearDownClass(cls):
         super(test_concept_Base, cls).tearDownClass()
-        print("Closing session")
         global session, client
         session.close()
         # clear the test keyspace

--- a/tests/integration/test_keyspace.py
+++ b/tests/integration/test_keyspace.py
@@ -21,17 +21,30 @@ import unittest
 import grakn
 from tests.integration.base import test_Base
 
-client = grakn.Grakn("localhost:48555")
+client = None
+session = None
 
 class test_Keyspace(test_Base):
+    @classmethod
+    def setUpClass(cls):
+        super(test_Keyspace, cls).setUpClass()
+        global client, session
+        client = grakn.GraknClient("localhost:48555")
+        session = client.session("keyspacetest")
 
-   def test_retrieve_delete(self):
+    @classmethod
+    def tearDownClass(cls):
+        super(test_Keyspace, cls).tearDownClass()
+        global client, session
+        session.close()
+        client.keyspaces().delete(session.keyspace)
+        client.close()
+
+    def test_retrieve_delete(self):
        """ Test retrieving and deleting a specific keyspace """
 
-       session = client.session(keyspace="keyspacetest")
        tx = session.transaction().write()
        tx.close()
-       session.close()
 
        keyspaces = client.keyspaces().retrieve()
        self.assertGreater(len(keyspaces), 0)

--- a/tests/integration/test_keyspace.py
+++ b/tests/integration/test_keyspace.py
@@ -29,8 +29,9 @@ class test_Keyspace(test_Base):
        """ Test retrieving and deleting a specific keyspace """
 
        session = client.session(keyspace="keyspacetest")
-       tx = session.transaction(grakn.TxType.WRITE)
+       tx = session.transaction().write()
        tx.close()
+       session.close()
 
        keyspaces = client.keyspaces().retrieve()
        self.assertGreater(len(keyspaces), 0)
@@ -40,8 +41,6 @@ class test_Keyspace(test_Base):
        post_delete_keyspaces = client.keyspaces().retrieve()
        self.assertFalse('keyspacetest' in post_delete_keyspaces)
 
-       session.close()
-       #client.keyspaces().delete("keyspacetest")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What is the goal of this PR?
Synchronizing client-python with the changes to client-java 

## What are the changes implemented in this PR?
Close issue #3: 
* create read/write tx with `session.transaction().read()/.write()`
* Rename `Grakn` -> `GraknClient`
* Sharing gRPC channel across sessions and keyspace service
* Update and refactor tests