### PR TITLE
Rename grakn-core-all-linux.tar.gz

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
           command: |
             bazel build @graknlabs_grakn_core//:assemble-linux-targz
             mkdir dist
-            tar -xvzf bazel-bin/external/graknlabs_grakn_core/assemble-linux-targz.tar.gz -C ./dist/
+            tar -xvzf bazel-bin/external/graknlabs_grakn_core/grakn-core-all-linux.tar.gz -C ./dist/
             nohup ./dist/grakn-core-all-linux/grakn server start
 
 jobs:


### PR DESCRIPTION
Adapts to newest naming