### PR TITLE
Add benchmark as transitive dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
       - checkout
       - run: sudo apt-get update
       - run: sudo apt-get install python-pip
-      - run: bazel run //:deploy-pip -- test $REPO_GRAKN_USERNAME $REPO_GRAKN_PASSWORD
+      - run: DEPLOYMENT_REPO_TYPE=test DEPLOYMENT_USERNAME=$REPO_GRAKN_USERNAME DEPLOYMENT_PASSWORD=$REPO_GRAKN_PASSWORD bazel run //:deploy-pip
       - run-grakn-server
       - run:
           name: Run test-deployment for client-python

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -94,9 +94,11 @@ python_grpc_compile()
 # Load Grakn Core dependencies #
 ################################
 
-load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl", "graknlabs_graql", "graknlabs_client_java")
+load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl",
+     "graknlabs_graql", "graknlabs_client_java", "graknlabs_benchmark")
 graknlabs_graql()
 graknlabs_client_java()
+graknlabs_benchmark()
 
 load("@graknlabs_grakn_core//dependencies/maven:dependencies.bzl",
 graknlabs_grakn_core_maven_dependencies = "maven_dependencies")


### PR DESCRIPTION
## What is the goal of this PR?
Fix breaking change caused by the introduction of `benchmark` repository as a Bazel git_repository dependency.

## What are the changes implemented in this PR?
One liner to include `graknlabs_benchmark()` dependency that allows the building of distribution `tar.gz` in CircleCI.
