### PR TITLE
Adapt to newest naming scheme

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
       - checkout
       - run: bazel run @graknlabs_build_tools//ci:release-approval
 
-  release-github:
+  deploy-github:
     machine: true
     working_directory: ~/client-python
     steps:
@@ -107,7 +107,7 @@ jobs:
       - checkout
       - run: bazel run //:deploy-github
 
-  release-pypi:
+  deploy-pypi:
     machine: true
     working_directory: ~/client-python
     steps:
@@ -153,26 +153,26 @@ workflows:
 
   client-python-release:
     jobs:
-      - release-github:
+      - deploy-github:
           filters:
             branches:
               only: client-python-release-branch
-      - release-deployment-approval:
+      - deploy-approval:
           type: approval
           requires:
-            - release-github
+            - deploy-github
           filters:
             branches:
               only: client-python-release-branch
-      - release-pypi:
+      - deploy-pypi:
           requires:
-            - release-deployment-approval
+            - deploy-approval
           filters:
             branches:
               only: client-python-release-branch
       - release-cleanup:
           requires:
-            - release-pypi
+            - deploy-pypi
           filters:
             branches:
               only: client-python-release-branch


### PR DESCRIPTION
## What is the goal of this PR?

Adapt to newest naming conventions for naming CircleCI jobs

## What are the changes implemented in this PR?

Rename `release-*` to `deploy-*` in CircleCI config