### PR TITLE
//:test-integration now depends on @graknlabs_grakn_core//:assemble-mac-zip

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
       - checkout
       - run-grakn-server
       - run-bazel-rbe:
-          command: bazel test //:test_integration --test_output=streamed --spawn_strategy=local
+          command: bazel test //:test_integration --test_output=streamed
 
   deploy-pip-snapshot:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,8 @@ jobs:
       - install-bazel-linux-rbe
       - checkout
       - run-grakn-server
-      - run: bazel test //:test_integration --test_output=streamed
+      - run-bazel-rbe:
+          command: bazel test //:test_integration --test_output=streamed --spawn_strategy=local
 
   deploy-pip-snapshot:
     machine: true

--- a/BUILD
+++ b/BUILD
@@ -124,6 +124,7 @@ py_test(
         ":client_python",
         graknlabs_client_python_requirement("forbiddenfruit")
     ],
+    data = ["@graknlabs_grakn_core//:assemble-mac-zip"],
     imports = ["."]
 )
 
@@ -137,6 +138,7 @@ py_test(
         ":client_python",
         graknlabs_client_python_requirement("forbiddenfruit")
     ],
+    data = ["@graknlabs_grakn_core//:assemble-mac-zip"],
     imports = ["."]
 )
 
@@ -150,6 +152,7 @@ py_test(
         ":client_python",
         graknlabs_client_python_requirement("forbiddenfruit")
     ],
+    data = ["@graknlabs_grakn_core//:assemble-mac-zip"],
     imports = ["."]
 )
 

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -61,11 +61,6 @@ class GraknServer(object):
     def __init__(self):
         self.__unpacked_dir = None
 
-    def _unpack(self):
-        self.__unpacked_dir = tempfile.mkdtemp(prefix='grakn')
-        with ZipFile(GraknServer.DISTRIBUTION_LOCATION) as zf:
-            zf.extractall(self.__unpacked_dir)
-
     def __enter__(self):
         if not self.__unpacked_dir:
             self._unpack()
@@ -78,6 +73,11 @@ class GraknServer(object):
             'grakn', 'server', 'stop'
         ], cwd=os.path.join(self.__unpacked_dir, GraknServer.DISTRIBUTION_ROOT_DIR))
         shutil.rmtree(self.__unpacked_dir)
+
+    def _unpack(self):
+        self.__unpacked_dir = tempfile.mkdtemp(prefix='grakn')
+        with ZipFile(GraknServer.DISTRIBUTION_LOCATION) as zf:
+            zf.extractall(self.__unpacked_dir)
 
 
 class test_Base(TestCase):

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -54,7 +54,7 @@ class ZipFile(zipfile.ZipFile):
         return ret_val
 
 
-class GraknDistribution(object):
+class GraknServer(object):
     DISTRIBUTION_LOCATION = 'external/graknlabs_grakn_core/grakn-core-all-mac.zip'
     DISTRIBUTION_ROOT_DIR = 'grakn-core-all-mac'
 
@@ -63,30 +63,20 @@ class GraknDistribution(object):
 
     def _unpack(self):
         self.__unpacked_dir = tempfile.mkdtemp(prefix='grakn')
-        with ZipFile(GraknDistribution.DISTRIBUTION_LOCATION) as zf:
+        with ZipFile(GraknServer.DISTRIBUTION_LOCATION) as zf:
             zf.extractall(self.__unpacked_dir)
 
-    @property
-    def __grakn_root_directory(self):
-        return os.path.join(self.__unpacked_dir, GraknDistribution.DISTRIBUTION_ROOT_DIR)
-
     def __enter__(self):
-        self.start()
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.stop()
-
-    def start(self):
         if not self.__unpacked_dir:
             self._unpack()
         sp.check_call([
             'grakn', 'server', 'start'
-        ], cwd=self.__grakn_root_directory)
+        ], cwd=os.path.join(self.__unpacked_dir, GraknServer.DISTRIBUTION_ROOT_DIR))
 
-    def stop(self):
+    def __exit__(self, exc_type, exc_val, exc_tb):
         sp.check_call([
             'grakn', 'server', 'stop'
-        ], cwd=self.__grakn_root_directory)
+        ], cwd=os.path.join(self.__unpacked_dir, GraknServer.DISTRIBUTION_ROOT_DIR))
         shutil.rmtree(self.__unpacked_dir)
 
 

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -21,7 +21,13 @@ from unittest import TestCase
 from datetime import datetime
 from forbiddenfruit import curse
 
+import os
+import shutil
 import six
+import subprocess as sp
+import tempfile
+import zipfile
+
 
 class DummyContextManager(object):
     def __init__(self, *args, **kwargs):
@@ -32,6 +38,56 @@ class DummyContextManager(object):
 
     def __exit__(self, *args, **kwargs):
         pass
+
+
+class ZipFile(zipfile.ZipFile):
+    def extract(self, member, path=None, pwd=None):
+        if not isinstance(member, zipfile.ZipInfo):
+            member = self.getinfo(member)
+
+        if path is None:
+            path = os.getcwd()
+
+        ret_val = self._extract_member(member, path, pwd)
+        attr = member.external_attr >> 16
+        os.chmod(ret_val, attr)
+        return ret_val
+
+
+class GraknDistribution(object):
+    DISTRIBUTION_LOCATION = 'external/graknlabs_grakn_core/grakn-core-all-mac.zip'
+    DISTRIBUTION_ROOT_DIR = 'grakn-core-all-mac'
+
+    def __init__(self):
+        self.__unpacked_dir = None
+
+    def _unpack(self):
+        self.__unpacked_dir = tempfile.mkdtemp(prefix='grakn')
+        with ZipFile(GraknDistribution.DISTRIBUTION_LOCATION) as zf:
+            zf.extractall(self.__unpacked_dir)
+
+    @property
+    def __grakn_root_directory(self):
+        return os.path.join(self.__unpacked_dir, GraknDistribution.DISTRIBUTION_ROOT_DIR)
+
+    def __enter__(self):
+        self.start()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop()
+
+    def start(self):
+        if not self.__unpacked_dir:
+            self._unpack()
+        sp.check_call([
+            'grakn', 'server', 'start'
+        ], cwd=self.__grakn_root_directory)
+
+    def stop(self):
+        sp.check_call([
+            'grakn', 'server', 'stop'
+        ], cwd=self.__grakn_root_directory)
+        shutil.rmtree(self.__unpacked_dir)
 
 
 class test_Base(TestCase):

--- a/tests/integration/test_concept.py
+++ b/tests/integration/test_concept.py
@@ -24,7 +24,7 @@ import uuid
 from grakn.exception.GraknError import GraknError
 
 
-from tests.integration.base import test_Base, GraknDistribution
+from tests.integration.base import test_Base, GraknServer
 
 client = None
 session = None
@@ -758,5 +758,5 @@ class test_Relation(test_concept_Base):
 
 
 if __name__ == "__main__":
-    with GraknDistribution():
+    with GraknServer():
         unittest.main(verbosity=2)

--- a/tests/integration/test_concept.py
+++ b/tests/integration/test_concept.py
@@ -24,7 +24,7 @@ import uuid
 from grakn.exception.GraknError import GraknError
 
 
-from tests.integration.base import test_Base
+from tests.integration.base import test_Base, GraknDistribution
 
 client = None
 session = None
@@ -756,10 +756,7 @@ class test_Relation(test_concept_Base):
         double_filter_role_players = list(parentship.role_players(child_role, parent_role))
         self.assertEqual(len(double_filter_role_players), 2)
 
-        
 
-    
 if __name__ == "__main__":
-    unittest.main()
-
-    
+    with GraknDistribution():
+        unittest.main(verbosity=2)

--- a/tests/integration/test_grakn.py
+++ b/tests/integration/test_grakn.py
@@ -24,7 +24,7 @@ from grakn.client import GraknClient, DataType
 from grakn.exception.GraknError import GraknError
 from grakn.service.Session.util.ResponseReader import Value, ConceptList, ConceptSet, ConceptSetMeasure, AnswerGroup
 
-from tests.integration.base import test_Base, GraknDistribution
+from tests.integration.base import test_Base, GraknServer
 
 
 class test_client_PreDbSetup(test_Base):
@@ -429,5 +429,5 @@ class test_Transaction(test_client_Base):
 
 
 if __name__ == "__main__":
-    with GraknDistribution():
+    with GraknServer():
         unittest.main(verbosity=2)

--- a/tests/integration/test_grakn.py
+++ b/tests/integration/test_grakn.py
@@ -74,7 +74,8 @@ class test_client_PreDbSetup(test_Base):
         # test the `with` statement
         with a_inst.session('test') as session:
             self.assertIsInstance(session, grakn.client.Session)
-            tx = a_session.transaction().read()
+            tx = session.transaction().read()
+            tx.close()
 
         a_inst.close()
 

--- a/tests/integration/test_grakn.py
+++ b/tests/integration/test_grakn.py
@@ -35,6 +35,7 @@ class test_client_PreDbSetup(test_Base):
         """ Test valid URI """
         a_inst = GraknClient('localhost:48555')
         self.assertIsInstance(a_inst, GraknClient)
+        a_inst.close()
 
     def test_client_with_statement(self):
         """ Test that client is compatible with using `with` """
@@ -57,9 +58,11 @@ class test_client_PreDbSetup(test_Base):
             with a_inst.session("test") as s:
                 with s.transaction().read() as tx:
                     pass
+            a_inst.close()
 
 
     # --- Test client session for different keyspaces ---
+    @unittest.skip('does not close tx which causes hanging')
     def test_client_session_valid_keyspace(self):
         """ Test OK uri and keyspace """
         a_inst = GraknClient('localhost:48555')
@@ -81,6 +84,7 @@ class test_client_PreDbSetup(test_Base):
         with self.assertRaises(GraknError):
             a_session = inst2.session('')
             tx = a_session.transaction().read() # won't fail until opening a transaction
+        client.close()
 
     def test_client_session_close(self):
         client = GraknClient('localhost:48555')
@@ -88,6 +92,7 @@ class test_client_PreDbSetup(test_Base):
         a_session.close()
         with self.assertRaises(GraknError):
             a_session.transaction().read()
+        client.close()
 
     # --- Test grakn session transactions that are pre-DB setup ---
     def test_client_tx_valid_enum(self):
@@ -95,13 +100,14 @@ class test_client_PreDbSetup(test_Base):
         a_session = client.session('test')
         tx = a_session.transaction().read()
         self.assertIsInstance(tx, grakn.client.Transaction)
+        client.close()
 
     def test_client_tx_invalid_enum(self):
         client = GraknClient('localhost:48555')
         a_session = client.session('test')
         with self.assertRaises(Exception):
             a_session.transaction('foo')
-
+        client.close()
 
 
 client = None

--- a/tests/integration/test_grakn.py
+++ b/tests/integration/test_grakn.py
@@ -62,18 +62,21 @@ class test_client_PreDbSetup(test_Base):
 
 
     # --- Test client session for different keyspaces ---
-    @unittest.skip('does not close tx which causes hanging')
     def test_client_session_valid_keyspace(self):
         """ Test OK uri and keyspace """
         a_inst = GraknClient('localhost:48555')
         a_session = a_inst.session('test')
         self.assertIsInstance(a_session, grakn.client.Session)
-        tx = a_session.transaction().read() # won't fail until opening a transaction
+        tx = a_session.transaction().read()
+        tx.close()
+        a_session.close()
 
         # test the `with` statement
         with a_inst.session('test') as session:
             self.assertIsInstance(session, grakn.client.Session)
-            tx = a_session.transaction().read() # won't fail until opening a transaction
+            tx = a_session.transaction().read()
+
+        a_inst.close()
 
     def test_client_session_invalid_keyspace(self):
         client = GraknClient('localhost:48555')

--- a/tests/integration/test_grakn.py
+++ b/tests/integration/test_grakn.py
@@ -24,7 +24,7 @@ from grakn.client import GraknClient, DataType
 from grakn.exception.GraknError import GraknError
 from grakn.service.Session.util.ResponseReader import Value, ConceptList, ConceptSet, ConceptSetMeasure, AnswerGroup
 
-from tests.integration.base import test_Base
+from tests.integration.base import test_Base, GraknDistribution
 
 
 class test_client_PreDbSetup(test_Base):
@@ -426,6 +426,8 @@ class test_Transaction(test_client_Base):
         rule = self.tx.put_rule(label, when, then)
         self.assertTrue(rule.is_rule())
         self.assertEqual(rule.label(), label)
-        
+
+
 if __name__ == "__main__":
-    unittest.main()
+    with GraknDistribution():
+        unittest.main(verbosity=2)

--- a/tests/integration/test_keyspace.py
+++ b/tests/integration/test_keyspace.py
@@ -19,7 +19,7 @@
 
 import unittest
 from grakn.client import GraknClient
-from tests.integration.base import test_Base, GraknDistribution
+from tests.integration.base import test_Base, GraknServer
 
 client = None
 session = None
@@ -56,5 +56,5 @@ class test_Keyspace(test_Base):
 
 
 if __name__ == "__main__":
-    with GraknDistribution():
+    with GraknServer():
         unittest.main(verbosity=2)

--- a/tests/integration/test_keyspace.py
+++ b/tests/integration/test_keyspace.py
@@ -19,7 +19,7 @@
 
 import unittest
 from grakn.client import GraknClient
-from tests.integration.base import test_Base
+from tests.integration.base import test_Base, GraknDistribution
 
 client = None
 session = None
@@ -55,6 +55,6 @@ class test_Keyspace(test_Base):
        self.assertFalse('keyspacetest' in post_delete_keyspaces)
 
 
-
 if __name__ == "__main__":
-    unittest.main()
+    with GraknDistribution():
+        unittest.main(verbosity=2)


### PR DESCRIPTION
## What is the goal of this PR?

Test should unpack, start/stop Grakn distribution _within_ the test

## What are the changes implemented in this PR?

* tests now depend on `@graknlabs_grakn_core//:assemble-mac-zip` via `data`
* tests now unpack/start/stop Grakn before executing