### PR TITLE
Close Transactions Properly

### DIFF
--- a/grakn/service/Session/TransactionService.py
+++ b/grakn/service/Session/TransactionService.py
@@ -170,5 +170,7 @@ class Communicator(six.Iterator):
                 self._queue.queue.clear()
             self._queue.put(None)
             self._closed = True
+            # force exhaust the iterator so `onCompleted()` is called on the server
+            # note: next() was throwing an error sometimes, but would be preferable to a loop
             for empty in self._response_iterator:
                 pass

--- a/grakn/service/Session/TransactionService.py
+++ b/grakn/service/Session/TransactionService.py
@@ -155,7 +155,8 @@ class Communicator(six.Iterator):
             self._add_request(request)
             response = next(self._response_iterator)
         except Exception as e: # specialize into different gRPC exceptions?
-            # on any GRPC exception, close the stream
+            # invalidate this communicator, functionally this occurs automatically on exception (iterator not usable anymore)
+            self._closed = True
             raise GraknError("Server/network error: {0}\n\n generated from request: {1}".format(e, request))
 
         if response is None:

--- a/grakn/service/Session/TransactionService.py
+++ b/grakn/service/Session/TransactionService.py
@@ -169,3 +169,7 @@ class Communicator(six.Iterator):
             self._queue.queue.clear()
         self._queue.put(None)
         self._closed = True
+
+        # force the next() call on gRPC so that onCompleted() is called correctly on the server
+        for empty in self._response_iterator:
+            pass

--- a/grakn/service/Session/TransactionService.py
+++ b/grakn/service/Session/TransactionService.py
@@ -171,6 +171,7 @@ class Communicator(six.Iterator):
             self._queue.put(None)
             self._closed = True
             # force exhaust the iterator so `onCompleted()` is called on the server
-            # note: next() was throwing an error sometimes, but would be preferable to a loop
-            for empty in self._response_iterator:
+            try:
+                next(self._response_iterator)
+            except StopIteration:
                 pass

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -62,17 +62,19 @@ class GraknServer(object):
         self.__unpacked_dir = None
 
     def __enter__(self):
-        if not self.__unpacked_dir:
-            self._unpack()
-        sp.check_call([
-            'grakn', 'server', 'start'
-        ], cwd=os.path.join(self.__unpacked_dir, GraknServer.DISTRIBUTION_ROOT_DIR))
+        # if not self.__unpacked_dir:
+        #     self._unpack()
+        # sp.check_call([
+        #     'grakn', 'server', 'start'
+        # ], cwd=os.path.join(self.__unpacked_dir, GraknServer.DISTRIBUTION_ROOT_DIR))
+        pass
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        sp.check_call([
-            'grakn', 'server', 'stop'
-        ], cwd=os.path.join(self.__unpacked_dir, GraknServer.DISTRIBUTION_ROOT_DIR))
-        shutil.rmtree(self.__unpacked_dir)
+        # sp.check_call([
+        #     'grakn', 'server', 'stop'
+        # ], cwd=os.path.join(self.__unpacked_dir, GraknServer.DISTRIBUTION_ROOT_DIR))
+        # shutil.rmtree(self.__unpacked_dir)
+        pass
 
     def _unpack(self):
         self.__unpacked_dir = tempfile.mkdtemp(prefix='grakn')

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -62,19 +62,17 @@ class GraknServer(object):
         self.__unpacked_dir = None
 
     def __enter__(self):
-        # if not self.__unpacked_dir:
-        #     self._unpack()
-        # sp.check_call([
-        #     'grakn', 'server', 'start'
-        # ], cwd=os.path.join(self.__unpacked_dir, GraknServer.DISTRIBUTION_ROOT_DIR))
-        pass
+        if not self.__unpacked_dir:
+            self._unpack()
+        sp.check_call([
+            'grakn', 'server', 'start'
+        ], cwd=os.path.join(self.__unpacked_dir, GraknServer.DISTRIBUTION_ROOT_DIR))
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        # sp.check_call([
-        #     'grakn', 'server', 'stop'
-        # ], cwd=os.path.join(self.__unpacked_dir, GraknServer.DISTRIBUTION_ROOT_DIR))
-        # shutil.rmtree(self.__unpacked_dir)
-        pass
+        sp.check_call([
+            'grakn', 'server', 'stop'
+        ], cwd=os.path.join(self.__unpacked_dir, GraknServer.DISTRIBUTION_ROOT_DIR))
+        shutil.rmtree(self.__unpacked_dir)
 
     def _unpack(self):
         self.__unpacked_dir = tempfile.mkdtemp(prefix='grakn')

--- a/tests/integration/test_concept.py
+++ b/tests/integration/test_concept.py
@@ -77,12 +77,12 @@ class test_concept_Base(test_Base):
     def setUp(self):
         global session
         self.tx = session.transaction().write()
-        self.addCleanup(self.cleanupTransaction, [self.tx])     # ensure tx closed even on test failure
+        self.addCleanup(self.cleanupTransaction, self.tx)     # ensure tx closed even on test failure
 
     def tearDown(self):
         self.tx.close()
 
-    def cleanupTransaction(cls, tx):
+    def cleanupTransaction(self, tx):
         tx.close()
 
 

--- a/tests/integration/test_concept.py
+++ b/tests/integration/test_concept.py
@@ -75,12 +75,15 @@ class test_concept_Base(test_Base):
         client.close()
 
     def setUp(self):
+        self.addCleanup(self.cleanupTransaction) # ensure tx closed even on test failure
         global session
         self.tx = session.transaction().write()
 
     def tearDown(self):
         self.tx.close()
 
+    def cleanupTransaction(self):
+        self.tx.close()
 
 
 class test_Concept(test_concept_Base):

--- a/tests/integration/test_concept.py
+++ b/tests/integration/test_concept.py
@@ -117,7 +117,9 @@ class test_Concept(test_concept_Base):
         with self.assertRaises(GraknError) as context:
             car.delete()
 
-    
+        self.assertTrue("FAILED_PRECONDITION" in str(context.exception))
+
+
     def test_is_each_schema_type(self):
         car_type = self.tx.put_entity_type("car")
         car = car_type.create()

--- a/tests/integration/test_concept.py
+++ b/tests/integration/test_concept.py
@@ -114,7 +114,7 @@ class test_Concept(test_concept_Base):
         none_car = self.tx.get_concept(car.id)
         self.assertIsNone(none_car)
 
-        with self.assertRaises(GraknError):
+        with self.assertRaises(GraknError) as context:
             car.delete()
 
     

--- a/tests/integration/test_concept.py
+++ b/tests/integration/test_concept.py
@@ -77,10 +77,8 @@ class test_concept_Base(test_Base):
     def setUp(self):
         global session
         self.tx = session.transaction().write()
-        self.addCleanup(self.cleanupTransaction, self.tx)     # ensure tx closed even on test failure
-
-    def tearDown(self):
-        self.tx.close()
+        # functions called by `addCleanup` are reliably called independent of test pass or failure
+        self.addCleanup(self.cleanupTransaction, self.tx)
 
     def cleanupTransaction(self, tx):
         tx.close()

--- a/tests/integration/test_concept.py
+++ b/tests/integration/test_concept.py
@@ -75,15 +75,15 @@ class test_concept_Base(test_Base):
         client.close()
 
     def setUp(self):
-        self.addCleanup(self.cleanupTransaction) # ensure tx closed even on test failure
         global session
         self.tx = session.transaction().write()
+        self.addCleanup(self.cleanupTransaction, [self.tx])     # ensure tx closed even on test failure
 
     def tearDown(self):
         self.tx.close()
 
-    def cleanupTransaction(self):
-        self.tx.close()
+    def cleanupTransaction(cls, tx):
+        tx.close()
 
 
 class test_Concept(test_concept_Base):

--- a/tests/integration/test_grakn.py
+++ b/tests/integration/test_grakn.py
@@ -163,12 +163,12 @@ class test_client_Base(test_Base):
     def setUp(self):
         global session
         self.tx = session.transaction().write()
-        self.addCleanup(self.cleanupTransaction, [self.tx])     # ensure tx closed even on test failure
+        self.addCleanup(self.cleanupTransaction, self.tx)     # ensure tx closed even on test failure
 
     def tearDown(self):
         self.tx.close()
 
-    def cleanupTransaction(cls, tx):
+    def cleanupTransaction(self, tx):
         tx.close()
 
 

--- a/tests/integration/test_grakn.py
+++ b/tests/integration/test_grakn.py
@@ -161,15 +161,15 @@ class test_client_Base(test_Base):
         client.close()
 
     def setUp(self):
-        self.addCleanup(self.cleanupTransaction) # ensure tx closed even on test failure
         global session
         self.tx = session.transaction().write()
+        self.addCleanup(self.cleanupTransaction, [self.tx])     # ensure tx closed even on test failure
 
     def tearDown(self):
         self.tx.close()
 
-    def cleanupTransaction(self):
-        self.tx.close()
+    def cleanupTransaction(cls, tx):
+        tx.close()
 
 
 

--- a/tests/integration/test_grakn.py
+++ b/tests/integration/test_grakn.py
@@ -163,10 +163,8 @@ class test_client_Base(test_Base):
     def setUp(self):
         global session
         self.tx = session.transaction().write()
-        self.addCleanup(self.cleanupTransaction, self.tx)     # ensure tx closed even on test failure
-
-    def tearDown(self):
-        self.tx.close()
+        # functions called by `addCleanup` are reliably called independent of test pass or failure
+        self.addCleanup(self.cleanupTransaction, self.tx)
 
     def cleanupTransaction(self, tx):
         tx.close()

--- a/tests/integration/test_grakn.py
+++ b/tests/integration/test_grakn.py
@@ -161,9 +161,14 @@ class test_client_Base(test_Base):
         client.close()
 
     def setUp(self):
+        self.addCleanup(self.cleanupTransaction) # ensure tx closed even on test failure
+        global session
         self.tx = session.transaction().write()
 
     def tearDown(self):
+        self.tx.close()
+
+    def cleanupTransaction(self):
         self.tx.close()
 
 


### PR DESCRIPTION
## What is the goal of this PR?
Properly close transactions that was leading to failing client-python tests, and ensure that tests that are failing clean up properly rather than exiting without closing transactions. 

## What are the changes implemented in this PR?
* Exhaust the gRPC iterator when the transaction is closed to ensure that `onCompleted()` is called on the server. Previously, we were emptying the input iterator and adding `None` to its queue, but this was not being consumed. Thus, the transactions was not being cleaned up on the server as the `transaction(stream)` RPC call was never completed cleanly.
* Utilise `addCleanup` to close transactions even if the tests fail - this is always executed regardless of test status.

Closes #44 