### PR TITLE
Remove `Answer.explanations()`

### DIFF
--- a/grakn/service/Session/util/ResponseReader.py
+++ b/grakn/service/Session/util/ResponseReader.py
@@ -147,16 +147,6 @@ class Answer(object):
     def explanation(self):
         return self._explanation
 
-    def explanations(self):
-        if self._explanation is None:
-            return None
-        
-        explanations = set()
-        for concept_map in self._explanation.get_answers():
-            recursive_explanation_set = concept_map.explanations()
-            explanations = explanations.union(recursive_explanation_set)
-        return explanations
-
 class AnswerGroup(Answer):
 
     def __init__(self, owner_concept, answer_list, explanation):


### PR DESCRIPTION
## What is the goal of this PR?
Remove `Answer.explanations()` shortcut method that always returned empty set and is not documented and inconsistent with other APIs!

## What are the changes implemented in this PR?
Delete `Answer.explanations()`