### PR TITLE
Use same version for test-deployment as for deploy-pip-snapshot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ jobs:
       - install-bazel-linux-rbe
       - checkout
       - run: |
+          echo -n "$(cat VERSION)-$CIRCLE_SHA1" > VERSION
           export DEPLOY_PIP_USERNAME=$REPO_GRAKN_USERNAME
           export DEPLOY_PIP_PASSWORD=$REPO_GRAKN_PASSWORD
           bazel run //:deploy-pip -- snapshot


### PR DESCRIPTION
## What is the goal of this PR?

Recent introduction of `new_deploy_rpm` usage removed auto-appending commit SHA to `snapshot` deployments, which resulted in broken `test-deployment`. This PR fixes the version to be deployed into `snapshot` repo.

## What are the changes implemented in this PR?

Modify `VERSION` file to include commit SHA so that version in `deploy-pip-snapshot` and `test-deployment` are the same.