### PR TITLE
Use renamed rule from @graknlabs_bazel_distribution

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -23,7 +23,7 @@ load("@io_bazel_rules_python//python:python.bzl", "py_library", "py_test")
 load("@graknlabs_client_python_pip//:requirements.bzl",
        graknlabs_client_python_requirement = "requirement")
 
-load("@graknlabs_bazel_distribution//pip:rules.bzl", "assemble_pip", "new_deploy_pip")
+load("@graknlabs_bazel_distribution//pip:rules.bzl", "assemble_pip", "deploy_pip")
 load("@graknlabs_bazel_distribution_pip//:requirements.bzl",
        graknlabs_bazel_distribution_requirement = "requirement")
 
@@ -76,7 +76,7 @@ assemble_pip(
 )
 
 
-new_deploy_pip(
+deploy_pip(
     name = "deploy-pip",
     target = ":assemble-pip",
     deployment_properties = "@graknlabs_build_tools//:deployment.properties",

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,7 +22,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "e1875797063b86386072034e65af2f40dc1fb07c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "2112c007d1f2341d7d73b0a101ea139eefff58a4", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_grakn_core():


### PR DESCRIPTION
## What is the goal of this PR?

graknlabs/bazel-distribution#155 renamed `new_deploy_pip` to `deploy_pip` to have consistent naming. This PR utilizes new renamed rule.

## What are the changes implemented in this PR?

- Upgrade `@graknlabs_build_tools` to latest `master`
- Use `deploy_pip` in place of `new_deploy_pip`
