### PR TITLE
KGLIB sync dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
           export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
           bazel run @graknlabs_build_tools//ci:sync-dependencies -- \
           --source client-python@$CIRCLE_SHA1 \
-          --targets grakn-kgms:master docs:master examples:master
+          --targets grakn-kgms:master docs:master examples:master kglib:master
 
   release-approval:
     machine: true
@@ -146,7 +146,7 @@ jobs:
           export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN_GRABL
           bazel run @graknlabs_build_tools//ci:sync-dependencies -- \
           --source client-python@$(cat VERSION) \
-          --targets grakn-kgms:master docs:master examples:master
+          --targets grakn-kgms:master docs:master examples:master kglib:master
 
   release-cleanup:
     machine: true


### PR DESCRIPTION
## What is the goal of this PR?

We update CI to automatically update `graknlabs/kglib` such that it always depends upon the latest commit of `graknlabs/client-python`

## What are the changes implemented in this PR?

- Updates the targets of sync-dependencies jobs