### PR TITLE
Supply authentication credentials for keyspace operations

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -29,12 +29,12 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        commit = "e68b03e886986846346a260346bd6743ab967f2e" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "a1e73426c1c74155e6ab0e19d8992c22743bb579" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/graknlabs/protocol",
-        commit = "dbbea5ae6870dc0624658091c221fe9fc292bad1" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "f63c0771f37ab603f8e9f3100e06238f6cb85298" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )

--- a/grakn/client.py
+++ b/grakn/client.py
@@ -16,7 +16,7 @@ class GraknClient(object):
         self.uri = uri
         self.credentials = credentials
         self._channel = grpc.insecure_channel(uri)
-        self._keyspace_service = KeyspaceService(self.uri, self._channel)
+        self._keyspace_service = KeyspaceService(self.uri, self._channel, credentials)
 
     def session(self, keyspace):
         """ Open a session for a specific  keyspace. Can be used as `with Grakn('localhost:48555').session(keyspace='test') as session: ... ` or as normal assignment"""

--- a/grakn/service/Keyspace/KeyspaceService.py
+++ b/grakn/service/Keyspace/KeyspaceService.py
@@ -20,19 +20,27 @@
 from grakn_protocol.keyspace.Keyspace_pb2_grpc import KeyspaceServiceStub
 import grakn_protocol.keyspace.Keyspace_pb2 as keyspace_messages
 
+
 class KeyspaceService(object):
 
-    def __init__(self, uri, channel):
+    def __init__(self, uri, channel, credentials=None):
         self.uri = uri
         self.stub = KeyspaceServiceStub(channel)
+        self.credentials = credentials
 
     def retrieve(self):
         retrieve_request = keyspace_messages.Keyspace.Retrieve.Req()
+        if self.credentials:
+            retrieve_request.username = self.credentials['username']
+            retrieve_request.password = self.credentials['password']
         response = self.stub.retrieve(retrieve_request)
         return list(response.names)
 
     def delete(self, keyspace):
         delete_request = keyspace_messages.Keyspace.Delete.Req()
         delete_request.name = keyspace
+        if self.credentials:
+            delete_request.username = self.credentials['username']
+            delete_request.password = self.credentials['password']
         self.stub.delete(delete_request)
         return


### PR DESCRIPTION
## What is the goal of this PR?

Recent changes in protocol (graknlabs/protocol#7) allow keyspace operations to be authenticated. This PR adapts Grakn Client Python to these recent changes.

## What are the changes implemented in this PR?

- `KeyspaceService.retrieve` and `KeyspaceService.delete` now properly set credentials
- Bump `@graknlabs_protocol` and `@graknlabs_grakn_core` to latest version