### PR TITLE
Use correct variable name in sync-dependencies-release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
       - install-bazel-linux-rbe
       - checkout
       - run: |
-          export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN_GRABL
+          export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
           bazel run @graknlabs_build_tools//ci:sync-dependencies -- \
           --source client-python@$(cat VERSION) \
           --targets grakn-kgms:master docs:master examples:master kglib:master


### PR DESCRIPTION
## What is the goal of this PR?

Fix `sync-dependencies-release` of release CI pipeline

## What are the changes implemented in this PR?

Correctly assign `SYNC_DEPENDENCIES_TOKEN` (it was previously set to empty variable)