### PR TITLE
Adapt to latest @graknlabs_bazel_distribution

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -130,10 +130,15 @@ java_grpc_compile()
 load("@graknlabs_build_tools//bazel:dependencies.bzl", "bazel_rules_docker")
 bazel_rules_docker()
 
+##################################
+# Load Distribution dependencies #
+##################################
 
-# TODO: rename the macro we load here to deploy_github_dependencies
-load("@graknlabs_bazel_distribution//github:dependencies.bzl", "github_dependencies_for_deployment")
-github_dependencies_for_deployment()
+load("@graknlabs_bazel_distribution//github:dependencies.bzl", "tcnksm_ghr")
+tcnksm_ghr()
+
+load("@graknlabs_bazel_distribution//common:dependencies.bzl", "bazelbuild_rules_pkg")
+bazelbuild_rules_pkg()
 
 #####################################
 # Load Bazel common workspace rules #

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,7 +22,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "a5dabc91ac4031aa80312bab4c4f7c4971aaba26", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "d909d8401650c404d6a56081297235e47783005e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_grakn_core():


### PR DESCRIPTION
## What is the goal of this PR?

Newest changes in `bazel-distribution` (graknlabs/bazel-distribution#181) are backwards-incompatible.

## What are the changes implemented in this PR?

- Bump `@graknlabs_build_tools`'s version
- Uses workspace macros from most recent `bazel-distribution` version