### PR TITLE
Use release-validate-deps to ensure that client-python depends on a released version of protocol

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: git push --delete origin client-python-release-branch
+      - run: git push --delete https://$REPO_GITHUB_TOKEN@github.com/graknlabs/client-python $CIRCLE_BRANCH
 
 workflows:
   client-python:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,15 @@ jobs:
           export RELEASE_APPROVAL_TOKEN=$REPO_GITHUB_TOKEN
           bazel run @graknlabs_build_tools//ci:release-approval
 
+  release-validate:
+    machine: true
+    steps:
+      - install-bazel-linux-rbe
+      - checkout
+      - run: |
+          bazel run @graknlabs_build_tools//ci:release-validate-deps -- \
+            graknlabs_protocol
+
   deploy-github:
     machine: true
     working_directory: ~/client-python
@@ -193,10 +202,16 @@ workflows:
 
   client-python-release:
     jobs:
+      - release-validate:
+          filters:
+            branch:
+              only: client-python-release-branch
       - deploy-github:
           filters:
             branches:
               only: client-python-release-branch
+          requires:
+            - release-validate
       - deploy-approval:
           type: approval
           filters:


### PR DESCRIPTION
## What is the goal of this PR?

We have added a validation step using `//ci:release-validate-deps` in order to ensure that client-python is releasable only if it depends on a released version of protocol