### PR TITLE
Fix CI by using Python 2 to run tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ jobs:
     steps:
       - install-bazel-linux-rbe
       - checkout
+      - run: pyenv global 2.7.12 3.5.2
       - run-bazel-rbe:
           command: bazel test //:test_integration --test_output=streamed
 

--- a/BUILD
+++ b/BUILD
@@ -103,6 +103,7 @@ py_test(
         graknlabs_client_python_requirement("forbiddenfruit")
     ],
     data = ["@graknlabs_grakn_core//:assemble-mac-zip"],
+    python_version = "PY2"
 )
 
 py_test(
@@ -116,6 +117,7 @@ py_test(
         graknlabs_client_python_requirement("forbiddenfruit")
     ],
     data = ["@graknlabs_grakn_core//:assemble-mac-zip"],
+    python_version = "PY2"
 )
 
 py_test(
@@ -129,6 +131,7 @@ py_test(
         graknlabs_client_python_requirement("forbiddenfruit")
     ],
     data = ["@graknlabs_grakn_core//:assemble-mac-zip"],
+    python_version = "PY2"
 )
 
 test_suite(


### PR DESCRIPTION
## What is the goal of this PR?

Until `@rules_python` properly support installing Python 3 packages, we switch running Python tests back to Python 2

## What are the changes implemented in this PR?

- use `pyenv` to link `python` to `python2`
- specify `python_version` so `bazel` knows that tests need to be ran with Python 2