### PR TITLE
Refactor how version is provided to Python deployment rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,10 +66,9 @@ jobs:
       - install-bazel-linux-rbe
       - checkout
       - run: |
-          echo -n "$(cat VERSION)-$CIRCLE_SHA1" > VERSION
           export DEPLOY_PIP_USERNAME=$REPO_GRAKN_USERNAME
           export DEPLOY_PIP_PASSWORD=$REPO_GRAKN_PASSWORD
-          bazel run //:deploy-pip -- snapshot
+          bazel run --define version=$(git rev-parse HEAD) //:deploy-pip -- snapshot
 
   test-deployment:
     machine: true
@@ -83,7 +82,7 @@ jobs:
       - run:
           name: Run test-deployment for client-python
           command: |
-            echo -n "$(cat VERSION)-$CIRCLE_SHA1" > VERSION
+            echo -n "0.0.0-$CIRCLE_SHA1" > VERSION
             sed -i -e "s/CLIENT_PYTHON_VERSION_MARKER/$(cat VERSION)/g" tests/deployment/requirements.txt
             cat tests/deployment/requirements.txt
             pip install --upgrade pip
@@ -145,7 +144,7 @@ jobs:
       - run: |
           export DEPLOY_PIP_USERNAME=$REPO_PYPI_USERNAME
           export DEPLOY_PIP_PASSWORD=$REPO_PYPI_PASSWORD
-          bazel run //:deploy-pip -- release
+          bazel run --define version=$(cat VERSION) //:deploy-pip -- release
 
   sync-dependencies-release:
     machine: true

--- a/BUILD
+++ b/BUILD
@@ -46,7 +46,6 @@ py_library(
 assemble_pip(
     name = "assemble-pip",
     target = ":client_python",
-    version_file = "//:VERSION",
     package_name = "grakn-client",
     classifiers = [
         "Programming Language :: Python",

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,7 +22,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "07b1776bb1f0ef5a3766389a8bc23a8a30e1b0f8", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "54109ff7428d0b7c04bd30ecff6f7e77f32c1bfd", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_grakn_core():


### PR DESCRIPTION
## What is the goal of this PR?

graknlabs/bazel-distribution#195 changed how version is provided to `assemble_pip`. This PR adapts `client-python` to these changes.

## What are the changes implemented in this PR?

* Use `--define` to supply version
* Upgrade `@graknlabs_build_tools`
