### PR TITLE
Refactor how version is provided to deploy_github rule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
           bazel run @graknlabs_build_tools//ci:release-notes -- client-python $(cat VERSION) ./RELEASE_TEMPLATE.md
       - run: |
           export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
-          bazel run //:deploy-github -- $CIRCLE_SHA1
+          bazel run --define version=$(cat VERSION) //:deploy-github -- $CIRCLE_SHA1
 
   deploy-pip-release:
     machine: true

--- a/BUILD
+++ b/BUILD
@@ -88,7 +88,6 @@ deploy_github(
     title = "Grakn Client Python",
     title_append_version = True,
     deployment_properties = "//:deployment.properties",
-    version_file = "//:VERSION"
 )
 
 py_test(


### PR DESCRIPTION
## What is the goal of this PR?

Adapt `@graknlabs_client_python` to latest changes in bazel-distribution (in particular, graknlabs/bazel-distribution#150)

## What are the changes implemented in this PR?

Instead of supplying `version_file` everywhere, use `--define version=<>` as a Bazel argument to supply version.

