### PR TITLE
Rename is_closed to is_open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .ijwb
 .idea
 bazel-*
+__pycache__

--- a/grakn/client.py
+++ b/grakn/client.py
@@ -140,9 +140,9 @@ class Transaction(object):
         """ Close this transaction without committing """
         self._tx_service.close() # close the service
 
-    def is_closed(self):
-        """ Check if this transaction is closed """
-        return self._tx_service.is_closed()
+    def is_open(self):
+        """ Check if this transaction is open"""
+        return not self._tx_service.is_closed()
 
     def get_concept(self, concept_id):
         """ Retrieve a concept by Concept ID (string) """

--- a/tests/integration/test_grakn.py
+++ b/tests/integration/test_grakn.py
@@ -194,7 +194,7 @@ class test_Transaction(test_client_Base):
         with self.assertRaises(GraknError):
             # should be closed
             self.tx.query("match $x isa person; get;")
-        self.assertTrue(self.tx.is_closed(), msg="Tx is not closed after invalid syntax")
+        self.assertFalse(self.tx.is_open(), msg="Tx is not closed after invalid syntax")
 
 
     def test_query_tx_already_closed(self):
@@ -202,7 +202,7 @@ class test_Transaction(test_client_Base):
         with self.assertRaises(GraknError) :
             self.tx.query("match $x isa person; get;")
             
-        self.assertTrue(self.tx.is_closed(), msg="Tx is not closed after close()")
+        self.assertFalse(self.tx.is_open(), msg="Tx is not closed after close()")
 
     def test_no_metatype_duplicates(self):
         concepts = self.tx.query("match $x sub entity; get;").collect_concepts()
@@ -337,7 +337,7 @@ class test_Transaction(test_client_Base):
 
     def test_commit_check_tx_closed(self):
         self.tx.commit()
-        self.assertTrue(self.tx.is_closed(), msg="Tx not closed after commit")
+        self.assertFalse(self.tx.is_open(), msg="Tx not closed after commit")
 
     # --- close tests ---
 
@@ -348,7 +348,7 @@ class test_Transaction(test_client_Base):
         with self.assertRaises(Exception):
             self.tx.query("match $x isa person; get;")
 
-        self.assertTrue(self.tx.is_closed(), msg="Tx not closed after tx.close()")
+        self.assertFalse(self.tx.is_open(), msg="Tx not closed after tx.close()")
 
     # --- test get concept ---
     def test_get_concept(self):


### PR DESCRIPTION
## What is the goal of this PR?
To bring client-python in line with client-java, we rename the negative `tx.is_closed()` to the positive `tx.is_open()`.

## What are the changes implemented in this PR?
* Rename transaction status method
* Update `.gitignore`