### PR TITLE
Delete Queries return Void Answer Type, add Concept.is_deleted()

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -29,7 +29,7 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        commit = "50ced0fada14e4a2fda49d212d83f335d02dd0ca" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "14869e195f439f5dba20ad013524287319edb5b6" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():

--- a/grakn/service/Session/Concept/Concept.py
+++ b/grakn/service/Session/Concept/Concept.py
@@ -37,6 +37,11 @@ class Concept(object):
         method_response = self._tx_service.run_concept_method(self.id, del_request)
         return
 
+    def is_deleted(self):
+        retrieved = self._tx_service.get_concept(self.id)
+        return retrieved is None
+
+
     def is_schema_concept(self):
         """ Check if this concept is a schema concept """
         return isinstance(self, SchemaConcept)

--- a/grakn/service/Session/util/ResponseReader.py
+++ b/grakn/service/Session/util/ResponseReader.py
@@ -256,8 +256,8 @@ class Value(Answer):
         return self._number
 
 class Void(Answer):
-    def __init__(self, message, explanation):
-        super(Void, self).__init__(message, explanation)
+    def __init__(self, message):
+        super(Void, self).__init__(message, None)
         self._message = message
     __init__.__annotations__ = {'explanation': Explanation, 'message': str}
 

--- a/grakn/service/Session/util/ResponseReader.py
+++ b/grakn/service/Session/util/ResponseReader.py
@@ -257,7 +257,7 @@ class Value(Answer):
 
 class Void(Answer):
     def __init__(self, message):
-        super(Void, self).__init__(message, None)
+        super(Void, self).__init__(None)
         self._message = message
     __init__.__annotations__ = {'explanation': Explanation, 'message': str}
 

--- a/grakn/service/Session/util/ResponseReader.py
+++ b/grakn/service/Session/util/ResponseReader.py
@@ -259,9 +259,9 @@ class Void(Answer):
     def __init__(self, message, explanation):
         super(Void, self).__init__(message, explanation)
         self._message = message
-     __init__.__annotations__ = {'explanation': Explanation, 'message': str}
+    __init__.__annotations__ = {'explanation': Explanation, 'message': str}
 
-     def message(self):
+    def message(self):
         """ Get the message on this Void answer type """
         return self._message
 
@@ -349,8 +349,8 @@ class AnswerConverter(object):
             native_list_of_concept_maps.append(AnswerConverter._create_concept_map(tx_service, grpc_concept_map))
         return Explanation(query_pattern, native_list_of_concept_maps)
 
-     @staticmethod
-     def _create_void(tx_service, grpc_void):
+    @staticmethod
+    def _create_void(tx_service, grpc_void):
         """ Convert grpc Void message into an object """
         explanation = AnswerConverter._create_explanation(tx_service, grpc_void.explanation)
         return Void(grpc_void.message, explanation)

--- a/grakn/service/Session/util/ResponseReader.py
+++ b/grakn/service/Session/util/ResponseReader.py
@@ -255,6 +255,16 @@ class Value(Answer):
         """ Get as number (float or int) """
         return self._number
 
+class Void(Answer):
+    def __init__(self, message, explanation):
+        super(Void, self).__init__(message, explanation)
+        self._message = message
+     __init__.__annotations__ = {'explanation': Explanation, 'message': str}
+
+     def message(self):
+        """ Get the message on this Void answer type """
+        return self._message
+
 
 class AnswerConverter(object):
     """ Static methods to convert answers into Answer objects """
@@ -275,6 +285,8 @@ class AnswerConverter(object):
             return AnswerConverter._create_concept_set_measure(tx_service, grpc_answer.conceptSetMeasure)
         elif which_one == 'value':
             return AnswerConverter._create_value(tx_service, grpc_answer.value)
+        elif which_one == 'void':
+            return AnswerConverter._create_void(tx_service, grpc_answer.void)
         else:
             raise GraknError('Unknown gRPC Answer.answer message type: {0}'.format(which_one))
    
@@ -336,6 +348,12 @@ class AnswerConverter(object):
         for grpc_concept_map in grpc_list_of_concept_maps:
             native_list_of_concept_maps.append(AnswerConverter._create_concept_map(tx_service, grpc_concept_map))
         return Explanation(query_pattern, native_list_of_concept_maps)
+
+     @staticmethod
+     def _create_void(tx_service, grpc_void):
+        """ Convert grpc Void message into an object """
+        explanation = AnswerConverter._create_explanation(tx_service, grpc_void.explanation)
+        return Void(grpc_void.message, explanation)
 
     @staticmethod
     def _number_string_to_native(number):

--- a/grakn/service/Session/util/ResponseReader.py
+++ b/grakn/service/Session/util/ResponseReader.py
@@ -352,8 +352,7 @@ class AnswerConverter(object):
     @staticmethod
     def _create_void(tx_service, grpc_void):
         """ Convert grpc Void message into an object """
-        explanation = AnswerConverter._create_explanation(tx_service, grpc_void.explanation)
-        return Void(grpc_void.message, explanation)
+        return Void(grpc_void.message)
 
     @staticmethod
     def _number_string_to_native(number):

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -77,7 +77,6 @@ class GraknServer(object):
     def _unpack(self):
         self.__unpacked_dir = tempfile.mkdtemp(prefix='grakn')
         with ZipFile(GraknServer.DISTRIBUTION_LOCATION) as zf:
-            print(self.__unpacked_dir)
             zf.extractall(self.__unpacked_dir)
 
 

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -77,6 +77,7 @@ class GraknServer(object):
     def _unpack(self):
         self.__unpacked_dir = tempfile.mkdtemp(prefix='grakn')
         with ZipFile(GraknServer.DISTRIBUTION_LOCATION) as zf:
+            print(self.__unpacked_dir)
             zf.extractall(self.__unpacked_dir)
 
 

--- a/tests/integration/test_concept.py
+++ b/tests/integration/test_concept.py
@@ -117,6 +117,18 @@ class test_Concept(test_concept_Base):
 
         self.assertTrue("FAILED_PRECONDITION" in str(context.exception))
 
+    def test_is_deleted(self):
+        car_type = self.tx.put_entity_type("car")
+        car = car_type.create()
+        self.assertFalse(car.is_deleted())
+
+        car.delete()
+        self.assertTrue(car.is_deleted())
+
+        car2 = car_type.create()
+        self.tx.query("match $x isa car; delete $x;")
+        self.assertTrue(car2.is_deleted)
+
 
     def test_is_each_schema_type(self):
         car_type = self.tx.put_entity_type("car")

--- a/tests/integration/test_grakn.py
+++ b/tests/integration/test_grakn.py
@@ -22,7 +22,7 @@ import uuid
 import grakn
 from grakn.client import GraknClient, DataType
 from grakn.exception.GraknError import GraknError
-from grakn.service.Session.util.ResponseReader import Value, ConceptList, ConceptSet, ConceptSetMeasure, AnswerGroup
+from grakn.service.Session.util.ResponseReader import Value, ConceptList, ConceptSet, ConceptSetMeasure, AnswerGroup, Void
 
 from tests.integration.base import test_Base, GraknServer
 

--- a/tests/integration/test_grakn.py
+++ b/tests/integration/test_grakn.py
@@ -313,8 +313,22 @@ class test_Transaction(test_client_Base):
         client.keyspaces().delete("aggregategroup")
 
 
+    def test_delete_returns_void(self):
+        """ Test `match...delete`, response type should be Void"""
+        local_session = client.session("matchdelete_void")
+        tx = local_session.transaction().write()
+        result = list(tx.query("insert $x isa person;"))
+        inserted_person = result[0].get("x")
+        person_id = inserted_person.id()
 
-    # --- test different Answers and their APIs ---
+        void_result = list(tx.query("match $x id {0}; delete $x;".format(person_id)))[0]
+        self.assertEqual(type(void_result), Void)
+        self.assertTrue("success" in void_result.message())
+
+        self.assertTrue(inserted_person.is_deleted())
+        tx.close()
+        local_session.close()
+        client.keyspaces().delete("matchdelete_void")
 
 
 

--- a/tests/integration/test_grakn.py
+++ b/tests/integration/test_grakn.py
@@ -317,6 +317,7 @@ class test_Transaction(test_client_Base):
         """ Test `match...delete`, response type should be Void"""
         local_session = client.session("matchdelete_void")
         tx = local_session.transaction().write()
+        tx.query("define person sub entity;")
         result = list(tx.query("insert $x isa person;"))
         inserted_person = result[0].get("x")
         person_id = inserted_person.id()

--- a/tests/integration/test_grakn.py
+++ b/tests/integration/test_grakn.py
@@ -320,7 +320,7 @@ class test_Transaction(test_client_Base):
         tx.query("define person sub entity;")
         result = list(tx.query("insert $x isa person;"))
         inserted_person = result[0].get("x")
-        person_id = inserted_person.id()
+        person_id = inserted_person.id
 
         void_result = list(tx.query("match $x id {0}; delete $x;".format(person_id)))[0]
         self.assertEqual(type(void_result), Void)


### PR DESCRIPTION
## What is the goal of this PR?
As of https://github.com/graknlabs/protocol/pull/18, we have decided in a slight paradigm shift with `delete` queries:

1. straight delete queries `match...; delete...;` only return a message rather than the halfway house of all deleted Concept IDs (this was always awkward, should either return a Concept -- hard because vertex deleted, or nothing. We have opted for nothing).
2. If you want to know what was deleted, this implies your behavior was a _retrieve_ followed by a _delete_. This retrieve should be performed explicltly by the user not implicitly by Grakn, ie. a `match...; get...;` followed by `delete` using Concept API, or using a separate `match...; delete;` query.

Also, new method `is_deleted()` exists on all `Concept` as part of the Concept API.

## What are the changes implemented in this PR?
* Delete queries passed to the client now return `Void` answer type with a status message
* New Concept API method `is_deleted()` that checks if a concept has been deleted to facilitate usage of the new `delete` paradigm
