### PR TITLE
Delete collect_concepts

### DIFF
--- a/grakn/service/Session/util/ResponseReader.py
+++ b/grakn/service/Session/util/ResponseReader.py
@@ -354,17 +354,3 @@ class ResponseIterator(six.Iterator):
             raise StopIteration()
         else:
             return self._iter_resp_converter(self._tx_service, iter_response)
-
-    def collect_concepts(self):
-        """ Helper method to retrieve concepts from a query() method """
-        concepts = []
-        for answer in self:
-            if not isinstance(answer, ConceptMap):
-                raise GraknError("Only use .collect_concepts on ConceptMaps returned by query()")
-            concepts.extend(answer.map().values()) # get concept map => concepts
-        return concepts
-
-
-
-
-

--- a/tests/integration/test_concept.py
+++ b/tests/integration/test_concept.py
@@ -434,7 +434,7 @@ class test_Role(test_concept_Base):
     def test_relations(self):
         """ Test retrieving relations of a role """
         # parent role, parentship already exist
-        result = self.tx.query("match $x type parent; get;").collect_concepts()
+        result = [ans.get("x") for ans in self.tx.query("match $x type parent; get;")]
         parent_role = result[0]
         self.assertEqual(parent_role.base_type, "ROLE")
 
@@ -445,7 +445,7 @@ class test_Role(test_concept_Base):
 
     def test_players(self):
         """ Test retrieving entity types playing this role """
-        result = self.tx.query("match $x type parent; get;").collect_concepts()
+        result = [ans.get("x") for ans in self.tx.query("match $x type parent; get;")]
         parent_role = result[0]
         self.assertEqual(parent_role.base_type, "ROLE")
 
@@ -608,7 +608,7 @@ class test_Attribute(test_concept_Base):
         date_type = self.tx.put_attribute_type("birthdate", DataType.DATE)
         person_type = self.tx.get_schema_concept("person")
         person_type.has(date_type)
-        concepts = self.tx.query("insert $x isa person, has birthdate 2018-08-06;").collect_concepts()
+        concepts = [ans.get("x") for ans in self.tx.query("insert $x isa person, has birthdate 2018-08-06;")]
         person = concepts[0]
         attrs_iter = person.attributes()
         for attr_concept in attrs_iter:

--- a/tests/integration/test_grakn.py
+++ b/tests/integration/test_grakn.py
@@ -205,7 +205,7 @@ class test_Transaction(test_client_Base):
         self.assertFalse(self.tx.is_open(), msg="Tx is not closed after close()")
 
     def test_no_metatype_duplicates(self):
-        concepts = self.tx.query("match $x sub entity; get;").collect_concepts()
+        concepts = [ans.get("x") for ans in self.tx.query("match $x sub entity; get;")]
         self.assertEqual(len(concepts), 2) # entity and person
         id_set = set(concepts)
         self.assertEqual(len(id_set), 2) # entity and person, not the same
@@ -284,7 +284,7 @@ class test_Transaction(test_client_Base):
             middlename = middlename_attr_type.create("Billie")
     
             attr_concepts = self.tx.get_attributes_by_value("Billie", DataType.STRING)
-            attr_concepts = list(attr_concepts) # collect iterator
+            attr_concepts = list(attr_concepts) 
             self.assertEqual(len(attr_concepts), 2, msg="Do not have 2 first name attrs")
     
             ids = [attr.id for attr in attr_concepts]


### PR DESCRIPTION
## What is the goal of this PR?
Shortcut method `answer_iterator.collect_concepts()` was leading to user confusion as it can lead to duplicate concepts being returned in the same list. As it doesn't really fit with the general paradigm of simplifying and removing syntactic sugar, we delete this method and ask users to replace calls with a piece of custom code for now. 
Replacement is very easy when `collect_concepts` was associated with a query with 1 variable:
`[ans.get("x") for ans in answer_iterator]`


## What are the changes implemented in this PR?
* Delete `collect_concepts` and associated usage in tests