### PR TITLE
Avoids running `sync-dependencies-snapshot` on user-facing repositories

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
           export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
           bazel run @graknlabs_build_tools//ci:sync-dependencies -- \
           --source client-python@$CIRCLE_SHA1 \
-          --targets grakn-kgms:master docs:master examples:master kglib:master
+          --targets grakn-kgms:master kglib:master
 
   release-approval:
     machine: true


### PR DESCRIPTION
## What is the goal of this PR?
`examples` and `docs` are user-facing repositories that should always depend on the latest stable release of `client-python`. For this reason, they have been removed from targets of `sync-dependencies-snapshot`.