### PR TITLE
Fix excessive rebuilding

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,7 @@
+build --incompatible_strict_action_env
+run --incompatible_strict_action_env
+test --incompatible_strict_action_env
+
 build:rbe --project_id=grakn-dev
 build:rbe --remote_instance_name=projects/grakn-dev/instances/default_instance
 build:rbe --remote_cache=remotebuildexecution.googleapis.com


### PR DESCRIPTION
## What is the goal of this PR?

Previously, when switching between IDE and terminal builds, build cache would be fully invalidated. due to changed $PATH which defeats the sole purpose of caching. As per suggestion in [this](https://github.com/bazelbuild/intellij/issues/1169) thread, we're enabling strict environment for actions (which sets PATH alongside with other variables to minimally viable preconfigured values). 

## What are the changes implemented in this PR?

Specify `--incompatible_strict_action_env` for `build`/`test`/`run`