### PR TITLE
Relax strict dependencies on external packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ jobs:
     steps:
       - install-bazel-linux-rbe
       - checkout
+      - run: pyenv global 2.7.12 3.5.2
       - run-bazel-rbe:
           command: bazel build //...
 

--- a/BUILD
+++ b/BUILD
@@ -37,7 +37,7 @@ py_library(
         graknlabs_client_python_requirement("protobuf"),
         graknlabs_client_python_requirement("grpcio"),
         graknlabs_client_python_requirement("six"),
-        graknlabs_client_python_requirement("enum_compat"),
+        graknlabs_client_python_requirement("enum34"),
     ],
     visibility =["//visibility:public"]
 )
@@ -67,7 +67,7 @@ assemble_pip(
     author = "Grakn Labs",
     author_email = "community@grakn.ai",
     license = "Apache-2.0",
-    install_requires=['grpcio==1.24.1', 'protobuf==3.6.1', 'six>=1.11.0', 'enum-compat==0.0.2'],
+    install_requires=['grpcio==1.24.1', 'protobuf==3.6.1', 'six>=1.11.0', 'enum34; python_version < "3.4"'],
     keywords = ["grakn", "database", "graph", "knowledgebase", "knowledge-engineering"],
     description = "Grakn Client for Python",
     long_description_file = "//:README.md",

--- a/BUILD
+++ b/BUILD
@@ -67,7 +67,7 @@ assemble_pip(
     author = "Grakn Labs",
     author_email = "community@grakn.ai",
     license = "Apache-2.0",
-    install_requires=['grpcio==1.24.1', 'protobuf==3.6.1', 'six>=1.11.0', 'enum34; python_version < "3.4"'],
+    install_requires=['grpcio==1.24.1,<2', 'protobuf==3.6.1', 'six>=1.11.0', 'enum34; python_version < "3.4"'],
     keywords = ["grakn", "database", "graph", "knowledgebase", "knowledge-engineering"],
     description = "Grakn Client for Python",
     long_description_file = "//:README.md",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ protobuf==3.6.1
 six>=1.11.0
 forbiddenfruit==0.1.2
 # non-native Enum < 3.4 and Native Enum 3.4 onwards
-enum-compat==0.0.2
+enum34; python_version < "3.4"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-grpcio==1.24.1
+grpcio==1.24.1,<2
 protobuf==3.6.1
 six>=1.11.0
 forbiddenfruit==0.1.2


### PR DESCRIPTION
## What is the goal of this PR?

Some of our users reported issues on external dependencies being too strict.

## What are the changes implemented in this PR?

Relax dependencies such that any versions of `grpc` (as long as major is less that `2`) and `enum-compat` could be used
