### PR TITLE
Fix batch size to 50

### DIFF
--- a/grakn/service/Session/TransactionService.py
+++ b/grakn/service/Session/TransactionService.py
@@ -42,8 +42,8 @@ class TransactionService(object):
     # --- Passthrough targets ---
     # targets of top level Transaction class
 
-    def query(self, query, infer=True):
-        return ResponseReader.ResponseReader.get_query_results(self, Iterator(self._communicator, RequestBuilder.start_iterating_query(query, infer, 50)))
+    def query(self, query, infer=True, batch_size=50):
+        return ResponseReader.ResponseReader.get_query_results(self, Iterator(self._communicator, RequestBuilder.start_iterating_query(query, infer, batch_size)))
     query.__annotations__ = {'query': str}
 
     def commit(self):

--- a/grakn/service/Session/TransactionService.py
+++ b/grakn/service/Session/TransactionService.py
@@ -43,7 +43,7 @@ class TransactionService(object):
     # targets of top level Transaction class
 
     def query(self, query, infer=True):
-        return ResponseReader.ResponseReader.get_query_results(self, Iterator(self._communicator, RequestBuilder.start_iterating_query(query, infer)))
+        return ResponseReader.ResponseReader.get_query_results(self, Iterator(self._communicator, RequestBuilder.start_iterating_query(query, infer, 50)))
     query.__annotations__ = {'query': str}
 
     def commit(self):


### PR DESCRIPTION
## What is the goal of this PR?

To set the query batch size to 50 by default, rather than all. This was a mistake when releasing, the optional batch size in the RequestBuilder was intended to be used by the query method in the query thing. The batch size should also be optional for users who require small batches.

## What are the changes implemented in this PR?

- Batch size option available on queries, default value is 50.