### PR TITLE
Don't use Python 2 in sync-dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,6 @@ jobs:
     steps:
       - install-bazel-linux-rbe
       - checkout
-      - run: pyenv global 2.7.12 3.5.2
       - run: |
           export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
           bazel run @graknlabs_build_tools//ci:sync-dependencies -- \
@@ -160,7 +159,6 @@ jobs:
     steps:
       - install-bazel-linux-rbe
       - checkout
-      - run: pyenv global 2.7.12 3.5.2
       - run: |
           export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
           bazel run @graknlabs_build_tools//ci:sync-dependencies -- \


### PR DESCRIPTION
## What is the goal of this PR?

#94 introduced running `sync-dependencies` with Python 2. Apparently, it's not compatible so we revert the behaviour.

## What are the changes implemented in this PR?

Remove setting Python 2 as default for `sync-dependencies-snapshot`