### PR TITLE
Don't use Python 2 in deploy-github

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,6 @@ jobs:
     steps:
       - install-bazel-linux-rbe
       - checkout
-      - run: pyenv global 2.7.12 3.5.2
       - run: |
           pip install certifi
           export RELEASE_NOTES_TOKEN=$REPO_GITHUB_TOKEN


### PR DESCRIPTION
## What is the goal of this PR?

Currently, releasing new version is blocked due to not being able to run `deploy-github` job

## What are the changes implemented in this PR?

Remove setting Python 2 as default for `deploy-github`