### PR TITLE
Fix queries larger than 50

### DIFF
--- a/grakn/service/Session/util/RequestBuilder.py
+++ b/grakn/service/Session/util/RequestBuilder.py
@@ -79,8 +79,9 @@ class RequestBuilder(object):
     start_iterating_get_attributes_by_value = staticmethod(start_iterating_get_attributes_by_value)
 
     @staticmethod
-    def continue_iterating(iterator_id, batch_options=None):
-        transaction_iter_req = RequestBuilder._base_iterate_with_options(batch_options)
+    def continue_iterating(iterator_id, batch_options):
+        transaction_iter_req = transaction_messages.Transaction.Iter.Req()
+        transaction_iter_req.options.CopyFrom(batch_options)
         transaction_iter_req.iteratorId = iterator_id
         return transaction_iter_req
 

--- a/tests/integration/test_grakn.py
+++ b/tests/integration/test_grakn.py
@@ -180,13 +180,14 @@ class test_Transaction(test_client_Base):
         answers = self.tx.query("match $x isa person; get;")
         self.assertIsNotNone(answers)
 
-
     def test_query_empty_result(self):
+        """ Ensures that empty query results behave like empty iterators """
         answers = self.tx.query('match $x isa person, has age 9999; get;')
         with self.assertRaises(StopIteration):
             next(answers)
 
-    def test_large_query(self):
+    def test_query_with_multiple_batches(self):
+        """ Ensures that the query batching code works as intended and does not regress """
         self.tx.query('define giraffe sub entity;')
         for i in range(150):
             self.tx.query('insert $x isa giraffe;')

--- a/tests/integration/test_grakn.py
+++ b/tests/integration/test_grakn.py
@@ -186,6 +186,12 @@ class test_Transaction(test_client_Base):
         with self.assertRaises(StopIteration):
             next(answers)
 
+    def test_large_query(self):
+        self.tx.query('define giraffe sub entity;')
+        for i in range(150):
+            self.tx.query('insert $x isa giraffe;')
+        answers = self.tx.query('match $x isa giraffe; get $x;')
+        self.assertEquals(sum(1 for _ in answers), 150)
 
     def test_query_invalid_syntax(self):
         """ Invalid syntax -- expected behavior is an exception & closed transaction """


### PR DESCRIPTION
## What is the goal of this PR?

To fix a bug that caused queries with more than 50 results to fail. This case was not correctly covered with a regression test and that has now been fixed.

## What are the changes implemented in this PR?

- Added a test for queries with a size larger than 50 in order to trigger results batching.
- Fixed a mismatch between batch options and batch size.
