### PR TITLE
Upgrade tests and build to Python 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,6 @@ jobs:
     steps:
       - install-bazel-linux-rbe
       - checkout
-      - run: pyenv global 2.7.12 3.5.2
       - run-bazel-rbe:
           command: bazel build //...
 
@@ -55,7 +54,6 @@ jobs:
     steps:
       - install-bazel-linux-rbe
       - checkout
-      - run: pyenv global 2.7.12 3.5.2
       - run-bazel-rbe:
           command: bazel test //:test_integration --test_output=streamed
 
@@ -65,7 +63,6 @@ jobs:
     steps:
       - install-bazel-linux-rbe
       - checkout
-      - run: pyenv global 2.7.12 3.5.2
       - run: |
           export DEPLOY_PIP_USERNAME=$REPO_GRAKN_USERNAME
           export DEPLOY_PIP_PASSWORD=$REPO_GRAKN_PASSWORD
@@ -81,7 +78,6 @@ jobs:
       - run: sudo apt-get install python-pip
       - run-grakn-server
       - run: sleep 60
-      - run: pyenv global 2.7.12 3.5.2
       - run:
           name: Run test-deployment for client-python
           command: |
@@ -110,7 +106,6 @@ jobs:
     steps:
       - install-bazel-linux-rbe
       - checkout
-      - run: pyenv global 2.7.12 3.5.2
       - run: |
           export RELEASE_APPROVAL_USERNAME=$REPO_GITHUB_USERNAME
           export RELEASE_APPROVAL_TOKEN=$REPO_GITHUB_TOKEN
@@ -121,7 +116,6 @@ jobs:
     steps:
       - install-bazel-linux-rbe
       - checkout
-      - run: pyenv global 2.7.12 3.5.2
       - run: |
           bazel run @graknlabs_build_tools//ci:release-validate-deps -- \
             graknlabs_protocol
@@ -136,7 +130,6 @@ jobs:
           pip install certifi
           export RELEASE_NOTES_TOKEN=$REPO_GITHUB_TOKEN
           bazel run @graknlabs_build_tools//ci:release-notes -- client-python $(cat VERSION) ./RELEASE_TEMPLATE.md
-      - run: pyenv global 2.7.12 3.5.2
       - run: bazel clean --expunge
       - run: |
           export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
@@ -148,7 +141,6 @@ jobs:
     steps:
       - install-bazel-linux-rbe
       - checkout
-      - run: pyenv global 2.7.12 3.5.2
       - run: |
           export DEPLOY_PIP_USERNAME=$REPO_PYPI_USERNAME
           export DEPLOY_PIP_PASSWORD=$REPO_PYPI_PASSWORD

--- a/BUILD
+++ b/BUILD
@@ -17,7 +17,7 @@
 
 exports_files(["requirements.txt", "deployment.properties", "RELEASE_TEMPLATE.md"])
 
-load("@io_bazel_rules_python//python:python.bzl", "py_library", "py_test")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 
 load("@graknlabs_client_python_pip//:requirements.bzl",
        graknlabs_client_python_requirement = "requirement")
@@ -37,7 +37,6 @@ py_library(
         graknlabs_client_python_requirement("protobuf"),
         graknlabs_client_python_requirement("grpcio"),
         graknlabs_client_python_requirement("six"),
-        graknlabs_client_python_requirement("enum34"),
     ],
     visibility =["//visibility:public"]
 )
@@ -48,10 +47,7 @@ assemble_pip(
     package_name = "grakn-client",
     classifiers = [
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
@@ -67,7 +63,7 @@ assemble_pip(
     author = "Grakn Labs",
     author_email = "community@grakn.ai",
     license = "Apache-2.0",
-    install_requires=['grpcio==1.24.1,<2', 'protobuf==3.6.1', 'six>=1.11.0', 'enum34; python_version < "3.4"'],
+    install_requires=['grpcio==1.24.1,<2', 'protobuf==3.6.1', 'six>=1.11.0'],
     keywords = ["grakn", "database", "graph", "knowledgebase", "knowledge-engineering"],
     description = "Grakn Client for Python",
     long_description_file = "//:README.md",
@@ -97,10 +93,9 @@ py_test(
     ],
     deps = [
         ":client_python",
-        graknlabs_client_python_requirement("forbiddenfruit")
     ],
     data = ["@graknlabs_grakn_core//:assemble-mac-zip"],
-    python_version = "PY2"
+    python_version = "PY3"
 )
 
 py_test(
@@ -111,10 +106,9 @@ py_test(
     ],
     deps = [
         ":client_python",
-        graknlabs_client_python_requirement("forbiddenfruit")
     ],
     data = ["@graknlabs_grakn_core//:assemble-mac-zip"],
-    python_version = "PY2"
+    python_version = "PY3"
 )
 
 py_test(
@@ -125,10 +119,9 @@ py_test(
     ],
     deps = [
         ":client_python",
-        graknlabs_client_python_requirement("forbiddenfruit")
     ],
     data = ["@graknlabs_grakn_core//:assemble-mac-zip"],
-    python_version = "PY2"
+    python_version = "PY3"
 )
 
 py_test(
@@ -139,11 +132,10 @@ py_test(
     ],
     deps = [
         ":client_python",
-        graknlabs_client_python_requirement("forbiddenfruit")
     ],
     size = "large",
     data = ["@graknlabs_grakn_core//:assemble-mac-zip"],
-    python_version = "PY2"
+    python_version = "PY3"
 )
 
 test_suite(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -40,12 +40,15 @@ bazel_common()
 bazel_toolchain()
 bazel_rules_python()
 
-load("@io_bazel_rules_python//python:pip.bzl", "pip_repositories", "pip_import")
+load("@rules_python//python:repositories.bzl", "py_repositories")
+py_repositories()
+
+load("@rules_python//python:pip.bzl", "pip_repositories", "pip3_import")
 pip_repositories()
 
 # Python dependencies for @graknlabs_build_tools and @graknlabs_bazel_distribution
 
-pip_import(
+pip3_import(
     name = "graknlabs_build_tools_ci_pip",
     requirements = "@graknlabs_build_tools//ci:requirements.txt",
 )
@@ -53,7 +56,7 @@ load("@graknlabs_build_tools_ci_pip//:requirements.bzl",
 graknlabs_build_tools_ci_pip_install = "pip_install")
 graknlabs_build_tools_ci_pip_install()
 
-pip_import(
+pip3_import(
     name = "graknlabs_bazel_distribution_pip",
     requirements = "@graknlabs_bazel_distribution//pip:requirements.txt",
 )
@@ -66,7 +69,7 @@ graknlabs_bazel_distribution_pip_install()
 # Load Python dependencies #
 ############################
 
-pip_import(
+pip3_import(
     name = "graknlabs_client_python_pip",
     requirements = "//:requirements.txt",
 )

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -21,7 +21,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "6cf8cad67fa232d020869fde84e56984bf36d5e7", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "d543c564dd4bb6b6104e8e3ba36a7aab505efa09", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_grakn_core():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,3 @@
 grpcio==1.24.1,<2
 protobuf==3.6.1
 six>=1.11.0
-forbiddenfruit==0.1.2
-# non-native Enum < 3.4 and Native Enum 3.4 onwards
-enum34; python_version < "3.4"
-

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -20,7 +20,6 @@ from __future__ import print_function
 
 from unittest import TestCase
 from datetime import datetime
-from forbiddenfruit import curse
 
 import os
 import shutil
@@ -29,26 +28,12 @@ import subprocess as sp
 import tempfile
 import zipfile
 
-class DummyContextManager(object):
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def __enter__(self, *args, **kwargs):
-        pass
-
-    def __exit__(self, *args, **kwargs):
-        pass
-
 
 class ZipFile(zipfile.ZipFile):
-    def extract(self, member, path=None, pwd=None):
+    def _extract_member(self, member, targetpath, pwd):
         if not isinstance(member, zipfile.ZipInfo):
             member = self.getinfo(member)
-
-        if path is None:
-            path = os.getcwd()
-
-        ret_val = self._extract_member(member, path, pwd)
+        ret_val = super()._extract_member(member, targetpath, pwd)
         attr = member.external_attr >> 16
         os.chmod(ret_val, attr)
         return ret_val
@@ -86,17 +71,6 @@ class test_Base(TestCase):
     @classmethod
     def setUpClass(cls):
         super(test_Base, cls).setUpClass()
-
-        def _datetime_to_timestamp(self):
-            epoch = datetime(1970, 1, 1)
-            diff = self - epoch
-            return int(diff.total_seconds())
-
-        if six.PY2:
-            print('Patching datetime.timestamp for PY2')
-            print('Patching unittest.TestCase.subTest for PY2')
-            curse(datetime, 'timestamp', _datetime_to_timestamp)
-            curse(TestCase, 'subTest', DummyContextManager)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
## What is the goal of this PR?

In order to not increase tech debt, we're dropping support for Python 2 and run all tests on Python 3

## What are the changes implemented in this PR?

- Upgrade `@rules_python` (by using updated `@graknlabs_build_tools`)
- `enum34` and `forbiddenfruit` are no longer required
