### PR TITLE
Remove implicit, rename date to datetime, rename datatype to valuetype

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -21,7 +21,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "d543c564dd4bb6b6104e8e3ba36a7aab505efa09", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "abbee2441ccb14c5e9ff12eb7668ecc89d1c6b1d", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_grakn_core():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -27,13 +27,13 @@ def graknlabs_build_tools():
 def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
-        remote = "https://github.com/graknlabs/grakn",
-        commit = "ce41e8667d25cb13eeb3812662501cf6aa27cdc9" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        remote = "https://github.com/flyingsilverfin/grakn",
+        commit = "682809ef040a85b6c4c29c11fc78b3c9b42361fd" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/graknlabs/protocol",
-        commit = "1683f498bf7236283888fe0f620ea4eb0df9c7cf" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "61b04688abf4d7537bd9a783f0161cf4e4c24559" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -28,12 +28,12 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        commit = "fda48ff1557e674b061c2df135fe04634110c42f" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "ce41e8667d25cb13eeb3812662501cf6aa27cdc9" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/graknlabs/protocol",
-        tag = "1.0.5" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "1683f498bf7236283888fe0f620ea4eb0df9c7cf" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -21,7 +21,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "abbee2441ccb14c5e9ff12eb7668ecc89d1c6b1d", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "715e4802ea375abda44e24b2bb092ee14de72e42", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_grakn_core():

--- a/grakn/client.py
+++ b/grakn/client.py
@@ -19,7 +19,7 @@
 
 import grpc
 
-from grakn.service.Session.util.enums import DataType   # user-facing DataType enum
+from grakn.service.Session.util.enums import ValueType   # user-facing ValueType enum
 
 from grakn.service.Session.util.RequestBuilder import RequestBuilder
 from grakn.service.Session.util.enums import TxType as _TxType
@@ -176,13 +176,13 @@ class Transaction(object):
         return self._tx_service.get_schema_concept(label)
     get_schema_concept.__annotations__ = {'label': str}
 
-    def get_attributes_by_value(self, attribute_value, data_type):
-        """ Retrieve atttributes with a specific value and datatype
+    def get_attributes_by_value(self, attribute_value, value_type):
+        """ Retrieve atttributes with a specific value and value type
 
         :param any attribute_value: the value to match
-        :param grakn.DataType data_type: The data type of the value in Grakn, as given by the grakn.DataType enum
+        :param grakn.ValueType value_type: The value type of the value in Grakn, as given by the grakn.ValueType enum
         """
-        return self._tx_service.get_attributes_by_value(attribute_value, data_type)
+        return self._tx_service.get_attributes_by_value(attribute_value, value_type)
 
     def put_entity_type(self, label):
         """ Define a new entity type with the given label """
@@ -194,13 +194,13 @@ class Transaction(object):
         return self._tx_service.put_relation_type(label)
     put_relation_type.__annotations__ = {'label': str}
 
-    def put_attribute_type(self, label, data_type):
-        """ Define a new attribute type with the given label and data type
+    def put_attribute_type(self, label, value_type):
+        """ Define a new attribute type with the given label and value type
 
         :param str label: the label of the attribute type
-        :param grakn.DataType data_type: the data type of the value to be stored, as given by the grakn.DataType enum
+        :param grakn.ValueType value_type: the data type of the value to be stored, as given by the grakn.ValueType enum
         """
-        return self._tx_service.put_attribute_type(label, data_type)
+        return self._tx_service.put_attribute_type(label, value_type)
     put_attribute_type.__annotations__ = {'label': str}
 
     def put_role(self, label):

--- a/grakn/service/Session/Concept/Concept.py
+++ b/grakn/service/Session/Concept/Concept.py
@@ -102,17 +102,12 @@ class SchemaConcept(Concept):
     def __init__(self, grpc_concept):
         super(SchemaConcept, self).__init__(grpc_concept)
         self._label = grpc_concept.label_res.label
-        self._implicit = grpc_concept.isImplicit_res.implicit
 
     def label(self):
         """
         Get the label of this schema concept.
         """
         return self._label
-
-    def is_implicit(self):
-        """ Check if this schema concept is implicit """
-        return self._implicit
 
 
 class Type(SchemaConcept):
@@ -128,11 +123,11 @@ class AttributeType(Type):
     def __index__(self, grpc_concept):
         super(Type, self).__init__(grpc_concept)
         from grakn.service.Session.util import ResponseReader
-        self._data_type = ResponseReader.ResponseReader.from_grpc_data_type_res(grpc_concept.dataType_res)
+        self._value_type = ResponseReader.ResponseReader.from_grpc_value_type_res(grpc_concept.valueType_res)
 
-    def data_type(self):
-        """ Get the DataType enum (grakn.DataType) corresponding to the type of this attribute """
-        return self._data_type
+    def value_type(self):
+        """ Get the ValueType enum (grakn.ValueType) corresponding to the type of this attribute """
+        return self._value_type
 
 
 class RelationType(Type):

--- a/grakn/service/Session/Concept/RemoteConcept.py
+++ b/grakn/service/Session/Concept/RemoteConcept.py
@@ -125,12 +125,6 @@ class RemoteSchemaConcept(RemoteConcept):
             method_response = self._tx_service.run_concept_method(self.id, set_label_req)
             return self
 
-    def is_implicit(self):
-        """ Check if this schema concept is implicit """
-        is_implicit_req = RequestBuilder.ConceptMethod.SchemaConcept.is_implicit()
-        method_response = self._tx_service.run_concept_method(self.id, is_implicit_req)
-        return method_response.schemaConcept_isImplicit_res.implicit
-
     def sup(self, super_concept=None):
         """ 
         Get or set super schema concept.
@@ -284,8 +278,8 @@ class RemoteAttributeType(RemoteType):
 
     def create(self, value):
         """ Create an instance with this AttributeType """
-        self_data_type = self.data_type()
-        create_inst_req = RequestBuilder.ConceptMethod.AttributeType.create(value, self_data_type)
+        self_value_type = self.value_type()
+        create_inst_req = RequestBuilder.ConceptMethod.AttributeType.create(value, self_value_type)
         method_response = self._tx_service.run_concept_method(self.id, create_inst_req)
         grpc_attribute_concept = method_response.attributeType_create_res.attribute
         from grakn.service.Session.Concept import ConceptFactory
@@ -293,8 +287,8 @@ class RemoteAttributeType(RemoteType):
 
     def attribute(self, value):
         """ Retrieve an attribute instance by value if it exists """
-        self_data_type = self.data_type()
-        get_attribute_req = RequestBuilder.ConceptMethod.AttributeType.attribute(value, self_data_type)
+        self_value_type = self.value_type()
+        get_attribute_req = RequestBuilder.ConceptMethod.AttributeType.attribute(value, self_value_type)
         method_response = self._tx_service.run_concept_method(self.id, get_attribute_req)
         response = method_response.attributeType_attribute_res
         whichone = response.WhichOneof('res')
@@ -306,24 +300,24 @@ class RemoteAttributeType(RemoteType):
         else:
             raise GraknError("Unknown `res` key in AttributeType `attribute` response: {0}".format(whichone))
 
-    def data_type(self):
-        """ Get the DataType enum (grakn.DataType) corresponding to the type of this attribute """
-        get_data_type_req = RequestBuilder.ConceptMethod.AttributeType.data_type()
-        method_response = self._tx_service.run_concept_method(self.id, get_data_type_req)
-        response = method_response.attributeType_dataType_res
+    def value_type(self):
+        """ Get the ValueType enum (grakn.ValueType) corresponding to the type of this attribute """
+        get_value_type_req = RequestBuilder.ConceptMethod.AttributeType.value_type()
+        method_response = self._tx_service.run_concept_method(self.id, get_value_type_req)
+        response = method_response.attributeType_valueType_res
         whichone = response.WhichOneof('res')
-        if whichone == 'dataType':
-            # iterate over enum DataType enum to find matching data type
-            for e in enums.DataType:
-                if e.value == response.dataType:
+        if whichone == 'valueType':
+            # iterate over enum ValueType enum to find matching data type
+            for e in enums.ValueType:
+                if e.value == response.valueType:
                     return e
             else:
                 # loop exited normally
-                raise GraknError("Reported datatype NOT in enum: {0}".format(response.dataType))
+                raise GraknError("Reported valuetype NOT in enum: {0}".format(response.valueType))
         elif whichone == 'null':
             return None
         else:
-            raise GraknError("Unknown datatype response for AttributeType: {0}".format(whichone))
+            raise GraknError("Unknown valuetype response for AttributeType: {0}".format(whichone))
 
     def regex(self, pattern=None):
         """ Get or set regex """

--- a/grakn/service/Session/TransactionService.py
+++ b/grakn/service/Session/TransactionService.py
@@ -71,11 +71,11 @@ class TransactionService(object):
         return ResponseReader.ResponseReader.get_schema_concept(self, response.getSchemaConcept_res)
     get_schema_concept.__annotations__ = {'label': str}
 
-    def get_attributes_by_value(self, attribute_value, data_type):
-        request = RequestBuilder.start_iterating_get_attributes_by_value(attribute_value, data_type)
+    def get_attributes_by_value(self, attribute_value, value_type):
+        request = RequestBuilder.start_iterating_get_attributes_by_value(attribute_value, value_type)
         iterator = Iterator(self._communicator, request)
         return ResponseReader.ResponseReader.get_attributes_by_value(self, iterator)
-    get_attributes_by_value.__annotations__ = {'data_type': enums.DataType}
+    get_attributes_by_value.__annotations__ = {'value_type': enums.ValueType}
 
     def put_entity_type(self, label):
         request = RequestBuilder.put_entity_type(label)
@@ -89,11 +89,11 @@ class TransactionService(object):
         return ResponseReader.ResponseReader.put_relation_type(self, response.putRelationType_res)
     put_relation_type.__annotations__ = {'label': str}
 
-    def put_attribute_type(self, label, data_type):
-        request = RequestBuilder.put_attribute_type(label, data_type)
+    def put_attribute_type(self, label, value_type):
+        request = RequestBuilder.put_attribute_type(label, value_type)
         response = self._communicator.single_request(request)
         return ResponseReader.ResponseReader.put_attribute_type(self, response.putAttributeType_res)
-    put_attribute_type.__annotations__ = {'label': str, 'data_type': enums.DataType}
+    put_attribute_type.__annotations__ = {'label': str, 'value_type': enums.ValueType}
 
     def put_role(self, label):
         request = RequestBuilder.put_role(label)

--- a/grakn/service/Session/util/RequestBuilder.py
+++ b/grakn/service/Session/util/RequestBuilder.py
@@ -67,15 +67,15 @@ class RequestBuilder(object):
         transaction_iter_req.conceptMethod_iter_req.CopyFrom(transaction_concept_method_iter_req)
         return transaction_iter_req
 
-    def start_iterating_get_attributes_by_value(value, datatype, batch_size=None):
+    def start_iterating_get_attributes_by_value(value, valuetype, batch_size=None):
         get_attrs_req = transaction_messages.Transaction.GetAttributes.Iter.Req()
-        grpc_value_object = RequestBuilder.ConceptMethod.as_value_object(value, datatype)
+        grpc_value_object = RequestBuilder.ConceptMethod.as_value_object(value, valuetype)
         get_attrs_req.value.CopyFrom(grpc_value_object)
 
         transaction_iter_req = RequestBuilder._base_iterate_with_options(batch_size)
         transaction_iter_req.getAttributes_iter_req.CopyFrom(get_attrs_req)
         return transaction_iter_req
-    start_iterating_get_attributes_by_value.__annotations__ = {'datatype': enums.DataType}
+    start_iterating_get_attributes_by_value.__annotations__ = {'valuetype': enums.ValueType}
     start_iterating_get_attributes_by_value = staticmethod(start_iterating_get_attributes_by_value)
 
     @staticmethod
@@ -160,14 +160,14 @@ class RequestBuilder(object):
         transaction_req.putRelationType_req.CopyFrom(put_relation_type_req)
         return transaction_req
 
-    def put_attribute_type(label, data_type):
+    def put_attribute_type(label, value_type):
         put_attribute_type_req = transaction_messages.Transaction.PutAttributeType.Req()
         put_attribute_type_req.label = label
-        put_attribute_type_req.dataType = data_type.value # retrieve enum value
+        put_attribute_type_req.valueType = value_type.value # retrieve enum value
         transaction_req = transaction_messages.Transaction.Req()
         transaction_req.putAttributeType_req.CopyFrom(put_attribute_type_req)
         return transaction_req
-    put_attribute_type.__annotations__ = {'data_type': enums.DataType}
+    put_attribute_type.__annotations__ = {'value_type': enums.ValueType}
     put_attribute_type = staticmethod(put_attribute_type)
 
     @staticmethod
@@ -232,32 +232,32 @@ class RequestBuilder(object):
             grpc_concept.baseType = grpc_base_type
             return grpc_concept
 
-        def as_value_object(data, datatype):
+        def as_value_object(data, valuetype):
             msg = concept_messages.ValueObject()
-            if datatype == enums.DataType.STRING:
+            if valuetype == enums.ValueType.STRING:
                 msg.string = data
-            elif datatype == enums.DataType.BOOLEAN:
+            elif valuetype == enums.ValueType.BOOLEAN:
                 msg.boolean = data
-            elif datatype == enums.DataType.INTEGER:
+            elif valuetype == enums.ValueType.INTEGER:
                 msg.integer = data
-            elif datatype == enums.DataType.LONG:
+            elif valuetype == enums.ValueType.LONG:
                 msg.long = data
-            elif datatype == enums.DataType.FLOAT:
+            elif valuetype == enums.ValueType.FLOAT:
                 msg.float = data
-            elif datatype == enums.DataType.DOUBLE:
+            elif valuetype == enums.ValueType.DOUBLE:
                 msg.double = data
-            elif datatype == enums.DataType.DATE:
+            elif valuetype == enums.ValueType.DATETIME:
                 # convert local datetime into long
                 epoch = datetime(1970, 1, 1)
                 diff = data - epoch
                 epoch_seconds_utc = int(diff.total_seconds())
                 epoch_ms_long_utc = int(epoch_seconds_utc*1000)
-                msg.date = epoch_ms_long_utc 
+                msg.date = epoch_ms_long_utc
             else:
                 # TODO specialize exception
-                raise Exception("Unknown attribute datatype: {}".format(datatype))
+                raise Exception("Unknown attribute valuetype: {}".format(valuetype))
             return msg
-        as_value_object.__annotations__ = {'datatype': enums.DataType}
+        as_value_object.__annotations__ = {'valuetype': enums.ValueType}
         as_value_object = staticmethod(as_value_object)
 
 
@@ -280,12 +280,6 @@ class RequestBuilder(object):
                 concept_method_req.schemaConcept_setLabel_req.CopyFrom(set_schema_label_req)
                 return concept_method_req
 
-            @staticmethod
-            def is_implicit():
-                is_implicit_req = concept_messages.SchemaConcept.IsImplicit.Req()
-                concept_method_req = concept_messages.Method.Req()
-                concept_method_req.schemaConcept_isImplicit_req.CopyFrom(is_implicit_req)
-                return concept_method_req
 
             @staticmethod
             def get_sup():
@@ -501,8 +495,8 @@ class RequestBuilder(object):
             """ Generates AttributeType method messages """
             
             @staticmethod
-            def create(value, datatype):
-                grpc_value_object = RequestBuilder.ConceptMethod.as_value_object(value, datatype)
+            def create(value, valuetype):
+                grpc_value_object = RequestBuilder.ConceptMethod.as_value_object(value, valuetype)
                 create_attr_req = concept_messages.AttributeType.Create.Req()
                 create_attr_req.value.CopyFrom(grpc_value_object)
                 concept_method_req = concept_messages.Method.Req()
@@ -510,8 +504,8 @@ class RequestBuilder(object):
                 return concept_method_req
 
             @staticmethod
-            def attribute(value, datatype):
-                grpc_value_object = RequestBuilder.ConceptMethod.as_value_object(value, datatype)
+            def attribute(value, valuetype):
+                grpc_value_object = RequestBuilder.ConceptMethod.as_value_object(value, valuetype)
                 attribute_req = concept_messages.AttributeType.Attribute.Req()
                 attribute_req.value.CopyFrom(grpc_value_object)
                 concept_method_req = concept_messages.Method.Req()
@@ -519,10 +513,10 @@ class RequestBuilder(object):
                 return concept_method_req
 
             @staticmethod
-            def data_type():
-                datatype_req = concept_messages.AttributeType.DataType.Req()
+            def value_type():
+                valuetype_req = concept_messages.AttributeType.ValueType.Req()
                 concept_method_req = concept_messages.Method.Req()
-                concept_method_req.attributeType_dataType_req.CopyFrom(datatype_req)
+                concept_method_req.attributeType_valueType_req.CopyFrom(valuetype_req)
                 return concept_method_req
 
             @staticmethod
@@ -601,10 +595,10 @@ class RequestBuilder(object):
             @staticmethod
             def has(attribute_concept):
                 grpc_attribute_concept = RequestBuilder.ConceptMethod._concept_to_grpc_concept(attribute_concept)
-                relhas_req = concept_messages.Thing.Relhas.Req()
-                relhas_req.attribute.CopyFrom(grpc_attribute_concept)
+                has_req = concept_messages.Thing.Has.Req()
+                has_req.attribute.CopyFrom(grpc_attribute_concept)
                 concept_method_req = concept_messages.Method.Req()
-                concept_method_req.thing_relhas_req.CopyFrom(relhas_req)
+                concept_method_req.thing_has_req.CopyFrom(has_req)
                 return concept_method_req
 
             @staticmethod

--- a/grakn/service/Session/util/RequestBuilder.py
+++ b/grakn/service/Session/util/RequestBuilder.py
@@ -252,7 +252,7 @@ class RequestBuilder(object):
                 diff = data - epoch
                 epoch_seconds_utc = int(diff.total_seconds())
                 epoch_ms_long_utc = int(epoch_seconds_utc*1000)
-                msg.date = epoch_ms_long_utc
+                msg.datetime = epoch_ms_long_utc
             else:
                 # TODO specialize exception
                 raise Exception("Unknown attribute valuetype: {}".format(valuetype))

--- a/grakn/service/Session/util/ResponseReader.py
+++ b/grakn/service/Session/util/ResponseReader.py
@@ -95,7 +95,7 @@ class ResponseReader(object):
             return grpc_value_object.float
         elif whichone == 'double':
             return grpc_value_object.double
-        elif whichone == 'date':
+        elif whichone == 'datetime':
             epoch_ms_utc = grpc_value_object.date
             local_datetime_utc = datetime.datetime.fromtimestamp(float(epoch_ms_utc)/1000.)
             return local_datetime_utc

--- a/grakn/service/Session/util/ResponseReader.py
+++ b/grakn/service/Session/util/ResponseReader.py
@@ -96,7 +96,7 @@ class ResponseReader(object):
         elif whichone == 'double':
             return grpc_value_object.double
         elif whichone == 'datetime':
-            epoch_ms_utc = grpc_value_object.date
+            epoch_ms_utc = grpc_value_object.datetime
             local_datetime_utc = datetime.datetime.fromtimestamp(float(epoch_ms_utc)/1000.)
             return local_datetime_utc
         else:

--- a/grakn/service/Session/util/ResponseReader.py
+++ b/grakn/service/Session/util/ResponseReader.py
@@ -79,10 +79,10 @@ class ResponseReader(object):
     @staticmethod
     def from_grpc_value_object(grpc_value_object):
         whichone = grpc_value_object.WhichOneof('value')
-        # check the one is in the known datatypes
-        known_datatypes = [e.name.lower() for e in enums.DataType]
-        if whichone.lower() not in known_datatypes:
-            raise GraknError("Unknown value object value key: {0}, not in {1}".format(whichone, known_datatypes))
+        # check the one is in the known ValueTypes
+        known_valuetypes = [e.name.lower() for e in enums.ValueType]
+        if whichone.lower() not in known_valuetypes:
+            raise GraknError("Unknown value object value key: {0}, not in {1}".format(whichone, known_valuetypes))
         if whichone == 'string':
             return grpc_value_object.string
         elif whichone == 'boolean':
@@ -100,23 +100,23 @@ class ResponseReader(object):
             local_datetime_utc = datetime.datetime.fromtimestamp(float(epoch_ms_utc)/1000.)
             return local_datetime_utc
         else:
-            raise GraknError("Unknown datatype in enum but not handled in from_grpc_value_object")
+            raise GraknError("Unknown valuetype in enum but not handled in from_grpc_value_object")
 
     @staticmethod
-    def from_grpc_data_type_res(grpc_data_type_res):
-        whichone = grpc_data_type_res.WhichOneof('res')
-        if whichone == 'dataType':
-            # iterate over enum DataType enum to find matching data type
-            for e in enums.DataType:
-                if e.value == grpc_data_type_res.dataType:
+    def from_grpc_value_type_res(grpc_value_type_res):
+        whichone = grpc_value_type_res.WhichOneof('res')
+        if whichone == 'valueType':
+            # iterate over enum ValueType enum to find matching data type
+            for e in enums.ValueType:
+                if e.value == grpc_value_type_res.valueType:
                     return e
             else:
                 # loop exited normally
-                raise GraknError("Reported datatype NOT in enum: {0}".format(grpc_data_type_res.dataType))
+                raise GraknError("Reported valuetype NOT in enum: {0}".format(grpc_value_type_res.valueType))
         elif whichone == 'null':
             return None
         else:
-            raise GraknError("Unknown datatype response for AttributeType: {0}".format(whichone))
+            raise GraknError("Unknown valuetype response for AttributeType: {0}".format(whichone))
 
     # --- concept method helpers ---
 

--- a/grakn/service/Session/util/enums.py
+++ b/grakn/service/Session/util/enums.py
@@ -28,13 +28,13 @@ class TxType(Enum):
     BATCH = SessionMessages.Transaction.Type.Value('BATCH')
     
 
-data_type_map = {}
+VALUE_TYPE_map = {}
 
-class DataType(Enum):
-    STRING = ConceptMessages.AttributeType.DATA_TYPE.Value('STRING')
-    BOOLEAN = ConceptMessages.AttributeType.DATA_TYPE.Value('BOOLEAN')
-    INTEGER = ConceptMessages.AttributeType.DATA_TYPE.Value('INTEGER')
-    LONG = ConceptMessages.AttributeType.DATA_TYPE.Value('LONG')
-    FLOAT = ConceptMessages.AttributeType.DATA_TYPE.Value('FLOAT')
-    DOUBLE = ConceptMessages.AttributeType.DATA_TYPE.Value('DOUBLE')
-    DATE= ConceptMessages.AttributeType.DATA_TYPE.Value('DATE')
+class ValueType(Enum):
+    STRING = ConceptMessages.AttributeType.VALUE_TYPE.Value('STRING')
+    BOOLEAN = ConceptMessages.AttributeType.VALUE_TYPE.Value('BOOLEAN')
+    INTEGER = ConceptMessages.AttributeType.VALUE_TYPE.Value('INTEGER')
+    LONG = ConceptMessages.AttributeType.VALUE_TYPE.Value('LONG')
+    FLOAT = ConceptMessages.AttributeType.VALUE_TYPE.Value('FLOAT')
+    DOUBLE = ConceptMessages.AttributeType.VALUE_TYPE.Value('DOUBLE')
+    DATETIME= ConceptMessages.AttributeType.VALUE_TYPE.Value('DATE') #NOTE this is not quite in sync

--- a/grakn/service/Session/util/enums.py
+++ b/grakn/service/Session/util/enums.py
@@ -37,4 +37,4 @@ class ValueType(Enum):
     LONG = ConceptMessages.AttributeType.VALUE_TYPE.Value('LONG')
     FLOAT = ConceptMessages.AttributeType.VALUE_TYPE.Value('FLOAT')
     DOUBLE = ConceptMessages.AttributeType.VALUE_TYPE.Value('DOUBLE')
-    DATETIME= ConceptMessages.AttributeType.VALUE_TYPE.Value('DATE') #NOTE this is not quite in sync
+    DATETIME = ConceptMessages.AttributeType.VALUE_TYPE.Value('DATETIME')

--- a/tests/deployment/test.py
+++ b/tests/deployment/test.py
@@ -10,7 +10,7 @@ class PythonApplicationTest(TestCase):
         client = GraknClient("localhost:48555")
         session = client.session("define_schema")
         with session.transaction().write() as tx:
-            tx.query("define person sub entity, has name; name sub attribute, datatype string;")
+            tx.query("define person sub entity, has name; name sub attribute, value string;")
             tx.commit()
         session.close()
         client.close()
@@ -28,7 +28,7 @@ class PythonApplicationTest(TestCase):
         client = GraknClient("localhost:48555")
         session = client.session("define_schema")
         with session.transaction().write() as tx:
-            tx.query("define person sub entity, has name; name sub attribute, datatype string;")
+            tx.query("define person sub entity, has name; name sub attribute, value string;")
             tx.commit()
         with session.transaction().write() as tx:
             tx.query("insert $x isa person, has name \"john\";")

--- a/tests/integration/test_answer.py
+++ b/tests/integration/test_answer.py
@@ -130,9 +130,9 @@ class test_Answers(test_Base):
             inserted_person = result[0].get("x")
             person_id = inserted_person.id
 
-            void_result = list(tx.query("match $x id {0}; delete $x;".format(person_id)))[0]
+            void_result = list(tx.query("match $x id {0}; delete $x isa thing;".format(person_id)))[0]
             self.assertIsInstance(void_result, Void)
-            self.assertTrue("success" in void_result.message())
+            self.assertTrue("deleted" in void_result.message())
 
             self.assertTrue(inserted_person.as_remote(tx).is_deleted())
             tx.close()

--- a/tests/integration/test_answer.py
+++ b/tests/integration/test_answer.py
@@ -132,7 +132,7 @@ class test_Answers(test_Base):
 
             void_result = list(tx.query("match $x id {0}; delete $x isa thing;".format(person_id)))[0]
             self.assertIsInstance(void_result, Void)
-            self.assertTrue("deleted" in void_result.message())
+            self.assertTrue("Deleted" in void_result.message())
 
             self.assertTrue(inserted_person.as_remote(tx).is_deleted())
             tx.close()

--- a/tests/integration/test_concept.py
+++ b/tests/integration/test_concept.py
@@ -125,7 +125,7 @@ class test_Concept(test_concept_Base):
         self.assertTrue(car.is_deleted())
 
         car2 = car_type.create()
-        self.tx.query("match $x isa car; delete $x;")
+        self.tx.query("match $x isa car; delete $x isa car;")
         self.assertTrue(car2.is_deleted)
 
 
@@ -236,20 +236,19 @@ class test_Type(test_concept_Base):
         with self.subTest(i=0):
             person_schema_type = self.tx.get_schema_concept("person")
             person_plays = list(person_schema_type.playing())
-            # by default, they play 4 explicit roles and 2 @has-... roles 
-            self.assertEqual(len(person_plays), 6)
+            self.assertEqual(len(person_plays), 4)
         with self.subTest(i=1):
             person_schema_type.plays(father)
             updated_person_plays = person_schema_type.playing()
             labels = [role.label() for role in updated_person_plays]
-            self.assertEqual(len(labels), 7)
+            self.assertEqual(len(labels), 5)
             self.assertTrue("father" in labels)
         with self.subTest(i=2): 
             # remove role/plays from person
             person_schema_type.unplay(father)
             updated_person_plays = person_schema_type.playing()
             labels = [role.label() for role in updated_person_plays]
-            self.assertEqual(len(labels), 6)
+            self.assertEqual(len(labels), 4)
             self.assertFalse("father" in labels)
 
     def test_attributes_methods(self):

--- a/tests/integration/test_concept.py
+++ b/tests/integration/test_concept.py
@@ -18,7 +18,7 @@
 #
 
 import unittest
-from grakn.client import GraknClient, DataType
+from grakn.client import GraknClient, ValueType
 import datetime
 import uuid
 from grakn.exception.GraknError import GraknError
@@ -54,8 +54,8 @@ class test_concept_Base(test_Base):
                      "mother sub role; "
                      "son sub role; "
                      "person sub entity, has age, has gender, plays parent, plays child, plays mother, plays son; "
-                     "age sub attribute, datatype long; "
-                     "gender sub attribute, datatype string; "
+                     "age sub attribute, value long; "
+                     "gender sub attribute, value string; "
                      "parentship sub relation, relates parent, relates child, relates mother, relates son;")
         except GraknError as ce: 
             print(ce)
@@ -142,7 +142,7 @@ class test_Concept(test_concept_Base):
         self.assertFalse(owner.is_attribute())
         self.assertTrue(owner.is_relation())
 
-        attr_type = self.tx.put_attribute_type("age", DataType.LONG)
+        attr_type = self.tx.put_attribute_type("age", ValueType.LONG)
         age = attr_type.create(50)
         self.assertFalse(age.is_entity())
         self.assertTrue(age.is_attribute())
@@ -174,12 +174,6 @@ class test_SchemaConcept(test_concept_Base):
                 bike_type.label(100)
             self.assertIsNone(bike_type)
 
-    def test_is_implicit(self):
-        """ Test implicit schema concepts """
-        person = self.tx.get_schema_concept("person")
-        self.assertFalse(person.is_implicit())
-        implicit_concept = self.tx.get_schema_concept("@has-age")
-        self.assertTrue(implicit_concept.is_implicit())
 
     def test_get_sups(self):
         """ Test get super types of a schema concept -- recall a type is supertype of itself always """
@@ -261,7 +255,7 @@ class test_Type(test_concept_Base):
     def test_attributes_methods(self):
         """ Test get/set/delete attributes """
         person = self.tx.get_schema_concept("person")
-        haircolor_attr = self.tx.put_attribute_type("haircolor", DataType.STRING)
+        haircolor_attr = self.tx.put_attribute_type("haircolor", ValueType.STRING)
         with self.subTest(i=0):
             # get attrs
             current_attrs = person.attributes()
@@ -293,7 +287,7 @@ class test_Type(test_concept_Base):
     def test_key(self):
         """ Test get/set/delete key on Type """
         person_type = self.tx.get_schema_concept("person")
-        name_attr_type = self.tx.put_attribute_type('name', DataType.STRING)
+        name_attr_type = self.tx.put_attribute_type('name', ValueType.STRING)
 
         with self.subTest(i=0):
             # check current keys
@@ -324,36 +318,36 @@ class test_EntityType(test_concept_Base):
 class test_AttributeType(test_concept_Base):
 
     def test_create(self):
-        str_attr_type = self.tx.put_attribute_type("firstname", DataType.STRING)
+        str_attr_type = self.tx.put_attribute_type("firstname", ValueType.STRING)
         john = str_attr_type.create("john")
         self.assertTrue(john.is_attribute())
         self.assertEqual(john.value(), "john")
 
-        bool_attr_type = self.tx.put_attribute_type("employed", DataType.BOOLEAN)
+        bool_attr_type = self.tx.put_attribute_type("employed", ValueType.BOOLEAN)
         employed = bool_attr_type.create(True)
         self.assertEqual(employed.value(), True)
 
-        double_attr_type = self.tx.put_attribute_type("length", DataType.DOUBLE)
+        double_attr_type = self.tx.put_attribute_type("length", ValueType.DOUBLE)
         one = double_attr_type.create(1.0)
         self.assertEqual(one.value(), 1.0)
 
-    def test_data_type(self):
-        str_attr_type = self.tx.put_attribute_type("firstname", DataType.STRING)
-        self.assertEqual(str_attr_type.data_type(), DataType.STRING)
+    def test_value_type(self):
+        str_attr_type = self.tx.put_attribute_type("firstname", ValueType.STRING)
+        self.assertEqual(str_attr_type.value_type(), ValueType.STRING)
 
-        bool_attr_type = self.tx.put_attribute_type("employed", DataType.BOOLEAN)
-        self.assertEqual(bool_attr_type.data_type(), DataType.BOOLEAN)
+        bool_attr_type = self.tx.put_attribute_type("employed", ValueType.BOOLEAN)
+        self.assertEqual(bool_attr_type.value_type(), ValueType.BOOLEAN)
 
-        double_attr_type = self.tx.put_attribute_type("length", DataType.DOUBLE)
-        self.assertEqual(double_attr_type.data_type(), DataType.DOUBLE)
+        double_attr_type = self.tx.put_attribute_type("length", ValueType.DOUBLE)
+        self.assertEqual(double_attr_type.value_type(), ValueType.DOUBLE)
 
-        long_attr_type = self.tx.put_attribute_type("randomint", DataType.LONG)
-        self.assertEqual(long_attr_type.data_type(), DataType.LONG)
+        long_attr_type = self.tx.put_attribute_type("randomint", ValueType.LONG)
+        self.assertEqual(long_attr_type.value_type(), ValueType.LONG)
 
     def test_attribute(self):
         """ Test retrieve attribute instances """
 
-        name = self.tx.put_attribute_type("name", DataType.STRING)
+        name = self.tx.put_attribute_type("name", ValueType.STRING)
         john = name.create("john")
         
         with self.subTest(i=0):
@@ -368,7 +362,7 @@ class test_AttributeType(test_concept_Base):
 
     def test_regex(self):
         """ Test get/set regex """
-        attr_type = self.tx.put_attribute_type("dogbadness", DataType.STRING)
+        attr_type = self.tx.put_attribute_type("dogbadness", ValueType.STRING)
 
         empty_regex = attr_type.regex()
         self.assertEqual(len(empty_regex), 0, msg="Unset regex does not have length 0")
@@ -523,7 +517,7 @@ class test_Thing(test_concept_Base):
     def test_has_unhas_attributes(self):
         """ Test has/unhas/get attributes """
         person_type = self.tx.get_schema_concept("person")
-        name_attr_type = self.tx.put_attribute_type("name", DataType.STRING)
+        name_attr_type = self.tx.put_attribute_type("name", ValueType.STRING)
         person_type.has(name_attr_type)
         person = person_type.create()
         attr_john = name_attr_type.create("john")
@@ -540,9 +534,9 @@ class test_Thing(test_concept_Base):
     def test_attributes(self):
         """ Test retrieve attrs optionally narrowed by types """
         person_type = self.tx.get_schema_concept("person")
-        name_attr = self.tx.put_attribute_type("name", DataType.STRING)
-        foo_attr = self.tx.put_attribute_type("foo", DataType.BOOLEAN)
-        bar_attr = self.tx.put_attribute_type("bar", DataType.LONG)
+        name_attr = self.tx.put_attribute_type("name", ValueType.STRING)
+        foo_attr = self.tx.put_attribute_type("foo", ValueType.BOOLEAN)
+        bar_attr = self.tx.put_attribute_type("bar", ValueType.LONG)
         
         person_type.has(name_attr)
         person_type.has(foo_attr)
@@ -573,8 +567,8 @@ class test_Thing(test_concept_Base):
     def test_keys(self):
         """ Test retrieving keys optionally filtered by attribute types """
         person_type = self.tx.get_schema_concept("person")
-        name_type = self.tx.put_attribute_type("name", DataType.STRING)
-        surname_type = self.tx.put_attribute_type("surname", DataType.STRING)
+        name_type = self.tx.put_attribute_type("name", ValueType.STRING)
+        surname_type = self.tx.put_attribute_type("surname", ValueType.STRING)
         person_type.key(name_type)
         person_type.has(surname_type)
         
@@ -600,12 +594,12 @@ class test_Attribute(test_concept_Base):
 
     def test_value(self):
         """ Get attribute value """
-        double_attr_type = self.tx.put_attribute_type("length", DataType.DOUBLE)
+        double_attr_type = self.tx.put_attribute_type("length", ValueType.DOUBLE)
         double = double_attr_type.create(43.1)
         self.assertEqual(double.value(), 43.1)
 
     def test_get_date_value(self):
-        date_type = self.tx.put_attribute_type("birthdate", DataType.DATE)
+        date_type = self.tx.put_attribute_type("birthdate", ValueType.DATETIME)
         person_type = self.tx.get_schema_concept("person")
         person_type.has(date_type)
         concepts = [ans.get("x") for ans in self.tx.query("insert $x isa person, has birthdate 2018-08-06;")]
@@ -622,7 +616,7 @@ class test_Attribute(test_concept_Base):
                 return
 
     def test_set_date_value(self):
-        date_type = self.tx.put_attribute_type("birthdate", DataType.DATE)
+        date_type = self.tx.put_attribute_type("birthdate", ValueType.DATETIME)
         test_date = datetime.datetime(year=2018, month=6, day=6)
         date_attr_inst = date_type.create(test_date)
         value = date_attr_inst.value() # retrieve from server
@@ -633,7 +627,7 @@ class test_Attribute(test_concept_Base):
         """ Test retrieving entities that have an attribute """
         person_type = self.tx.get_schema_concept("person")
         animal_type = self.tx.put_entity_type("animal")
-        name_type = self.tx.put_attribute_type("name", DataType.STRING)
+        name_type = self.tx.put_attribute_type("name", ValueType.STRING)
         person_type.has(name_type)
         animal_type.has(name_type)
 

--- a/tests/integration/test_concept.py
+++ b/tests/integration/test_concept.py
@@ -753,8 +753,9 @@ class test_Relation(test_concept_Base):
         self.assertEqual(role_players[0].id, person.id)
 
         parentship.unassign(parent_role, person)
-        post_remove_role_players = list(parentship.role_players())
-        self.assertEqual(len(post_remove_role_players), 0)
+        self.assertFalse(parentship.is_deleted())
+#         post_remove_role_players = list(parentship.role_players())
+#         self.assertEqual(len(post_remove_role_players), 0)
 
     
     def test_role_players_filtered_by_role(self):

--- a/tests/integration/test_concept.py
+++ b/tests/integration/test_concept.py
@@ -753,9 +753,7 @@ class test_Relation(test_concept_Base):
         self.assertEqual(role_players[0].id, person.id)
 
         parentship.unassign(parent_role, person)
-        self.assertFalse(parentship.is_deleted())
-#         post_remove_role_players = list(parentship.role_players())
-#         self.assertEqual(len(post_remove_role_players), 0)
+        self.assertTrue(parentship.is_deleted())
 
     
     def test_role_players_filtered_by_role(self):

--- a/tests/integration/test_grakn.py
+++ b/tests/integration/test_grakn.py
@@ -20,7 +20,7 @@
 import unittest
 import uuid
 import grakn
-from grakn.client import GraknClient, DataType
+from grakn.client import GraknClient, ValueType
 from grakn.exception.GraknError import GraknError
 from grakn.service.Session.util.ResponseReader import Value
 
@@ -140,8 +140,8 @@ class test_client_Base(test_Base):
                          "mother sub role; "
                          "son sub role; "
                          "person sub entity, has age, has gender, plays parent, plays child, plays mother, plays son; "
-                         "age sub attribute, datatype long; "
-                         "gender sub attribute, datatype string; "
+                         "age sub attribute, value long; "
+                         "gender sub attribute, value string; "
                          "parentship sub relation, relates parent, relates child, relates mother, relates son;")
             except GraknError as ce:
                 print(ce)
@@ -289,12 +289,12 @@ class test_Transaction(test_client_Base):
         """ Retrieve attribute instances by value """
         with self.subTest(i=0):
             # test retrieving multiple concepts
-            firstname_attr_type = self.tx.put_attribute_type("firstname", DataType.STRING)
-            middlename_attr_type = self.tx.put_attribute_type("middlename", DataType.STRING)
+            firstname_attr_type = self.tx.put_attribute_type("firstname", ValueType.STRING)
+            middlename_attr_type = self.tx.put_attribute_type("middlename", ValueType.STRING)
             firstname = firstname_attr_type.create("Billie")
             middlename = middlename_attr_type.create("Billie")
     
-            attr_concepts = self.tx.get_attributes_by_value("Billie", DataType.STRING)
+            attr_concepts = self.tx.get_attributes_by_value("Billie", ValueType.STRING)
             attr_concepts = list(attr_concepts) 
             self.assertEqual(len(attr_concepts), 2, msg="Do not have 2 first name attrs")
     
@@ -304,7 +304,7 @@ class test_Transaction(test_client_Base):
         with self.subTest(i=1):
             # test retrieving no concepts
             # because we have no "Jean" attributes
-            jean_attrs = list(self.tx.get_attributes_by_value("Jean", DataType.STRING))
+            jean_attrs = list(self.tx.get_attributes_by_value("Jean", ValueType.STRING))
             self.assertEqual(len(jean_attrs), 0)
 
     # --- test schema modification ---
@@ -323,7 +323,7 @@ class test_Transaction(test_client_Base):
 
     def test_put_attribute_type(self):
         """ Test putting a new attribtue type in schema """
-        birthdate = self.tx.put_attribute_type("surname", DataType.DATE)
+        birthdate = self.tx.put_attribute_type("surname", ValueType.DATETIME)
         self.assertTrue(birthdate.is_schema_concept())
         self.assertTrue(birthdate.is_attribute_type())
 


### PR DESCRIPTION
## What is the goal of this PR?
This Change synchronises with changes in Grakn Core (https://github.com/graknlabs/grakn/pull/5722) that remove implicit types, and also updates to no longer use `date`, but instead use `datetime` (including a protocol update). Finally, we also propagate the change from `datatype` to `valuetype.


## What are the changes implemented in this PR?
* Bump `protocol` and `verification`
* use new `datetime` terminology where it wasn't before
* remove implicit, datatype (-> valuetype), and date (-> datetime)