### PR TITLE
Add future-style get for explicit waiting and error handling

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -27,8 +27,8 @@ def graknlabs_build_tools():
 def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
-        remote = "https://github.com/flyingsilverfin/grakn",
-        commit = "682809ef040a85b6c4c29c11fc78b3c9b42361fd" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        remote = "https://github.com/graknlabs/grakn",
+        commit = "81a0e888bfde0d29cbff60b5913d3fbf90f60c40" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():

--- a/grakn/service/Session/util/ResponseReader.py
+++ b/grakn/service/Session/util/ResponseReader.py
@@ -27,8 +27,8 @@ from six.moves import map
 class ResponseReader(object):
     
     @staticmethod
-    def get_query_results(tx_service, iterator):
-        return map(lambda iterate_res: AnswerConverter.convert(tx_service, iterate_res.query_iter_res.answer), iterator)
+    def get_query_results(tx_service):
+        return lambda iterate_res: AnswerConverter.convert(tx_service, iterate_res.query_iter_res.answer)
 
     @staticmethod
     def get_concept(tx_service, grpc_get_schema_concept):
@@ -53,8 +53,8 @@ class ResponseReader(object):
             raise GraknError("Unknown get_schema_concept response: {0}".format(which_one))
 
     @staticmethod
-    def get_attributes_by_value(tx_service, iterator):
-        return map(lambda iterate_res: ConceptFactory.create_remote_concept(tx_service, iterate_res.getAttributes_iter_res.attribute), iterator)
+    def get_attributes_by_value(tx_service):
+        return lambda iterate_res: ConceptFactory.create_remote_concept(tx_service, iterate_res.getAttributes_iter_res.attribute)
 
     @staticmethod
     def put_entity_type(tx_service, grpc_put_entity_type):

--- a/tests/integration/test_grakn.py
+++ b/tests/integration/test_grakn.py
@@ -217,6 +217,17 @@ class test_Transaction(test_client_Base):
         id_set = set(concepts)
         self.assertEqual(len(id_set), 2) # entity and person, not the same
 
+    def test_query_errors_async(self):
+        answer = self.tx.query("match $x isa unicorn; get;")
+
+        with self.assertRaises(GraknError):
+            answer.get()
+
+    def test_query_errors_async_on_commit(self):
+        self.tx.query("match $x isa unicorn; get;")
+
+        with self.assertRaises(GraknError):
+            self.tx.commit()
 
 
     # --- commit tests --- 


### PR DESCRIPTION
## What is the goal of this PR?

Since the introduction of asynchronous query processing, the error handling model has become less clear, as an error could be picked up on a line unrelated to its corresponding query. In order to allow clients to explicitly consume query completion, a `get()` method is added to the query result (iterator) which will block until the results are received, or throw an exception on error.

Clients looking to benefit from the asynchronous processing can continue without using the `get()` syntax.

## What are the changes implemented in this PR?

- Added a `get()` method on the iterator to block until it has received either positive results or an error.