### PR TITLE
Update gRPC to 1.29.0

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -28,12 +28,12 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        commit = "81a0e888bfde0d29cbff60b5913d3fbf90f60c40" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "616326903dec49d4c56a5fe20fb84e33cd928cfb" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/graknlabs/protocol",
-        commit = "61b04688abf4d7537bd9a783f0161cf4e4c24559" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "c95a81b7a739a75f2164335e9566a2a4ce892bfa" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-grpcio==1.24.1,<2
+grpcio==1.29.0,<2
 protobuf==3.6.1
 six>=1.11.0


### PR DESCRIPTION
## What is the goal of this PR?

- We have updated gRPC to 1.29.0
- We have also updated graknlabs dependencies to use ones that use gRPC 1.29.0