### PR TITLE
Remote building with BuildBarn

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,12 +2,11 @@ build --incompatible_strict_action_env
 run --incompatible_strict_action_env
 test --incompatible_strict_action_env
 
-build:rbe --project_id=grakn-dev
-build:rbe --remote_instance_name=projects/grakn-dev/instances/default_instance
-build:rbe --remote_cache=remotebuildexecution.googleapis.com
-build:rbe --remote_executor=remotebuildexecution.googleapis.com
-build:rbe --bes_backend="buildeventservice.googleapis.com"
-build:rbe --bes_results_url="https://source.cloud.google.com/results/invocations/"
+# what is defined in this section will be applied when bazel is invoked like this: bazel ... --config=rbe ...
+build:rbe --remote_instance_name=remote-execution
+build:rbe --remote_executor=grpc://bazel.grakn.ai
+build:rbe --bes_results_url=http://bazel.grakn.ai:8080/invocation/
+build:rbe --bes_backend=grpc://bazel.grakn.ai:1985
 build:rbe --host_platform=@graknlabs_build_tools//:rbe-ubuntu1604-network-standard
 build:rbe --platforms=@graknlabs_build_tools//:rbe-ubuntu1604-network-standard
 build:rbe --extra_execution_platforms=@graknlabs_build_tools//:rbe-ubuntu1604-network-standard
@@ -20,12 +19,4 @@ build:rbe --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/ba
 build:rbe --jobs=50
 build:rbe --remote_timeout=3600
 build:rbe --bes_timeout=60s
-build:rbe --tls_enabled=true
-build:rbe --auth_enabled=true
-build:rbe --spawn_strategy=remote
-build:rbe --strategy=Javac=remote
-build:rbe --strategy=Closure=remote
-build:rbe --genrule_strategy=remote
-build:rbe --define=EXECUTOR=remote
-build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:rbe --experimental_strict_action_env=true


### PR DESCRIPTION
## What is the goal of this PR?

As Google is going to shut down hosted solution for remote builds (RBE), we're migrating to our own self-hosted solution, BuildBarn. This PR updates URLs to point at it instead of RBE.

## What are the changes implemented in this PR?

Update `.bazelrc` to new URLs