### PR TITLE
Depend on artifact distribution for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - run-bazel:
           command: bazel build //...
 
-  test:
+  test-concept:
     machine: 
       image: ubuntu-1604:201903-01
     working_directory: ~/client-python
@@ -55,7 +55,37 @@ jobs:
       - install-bazel
       - checkout
       - run-bazel:
-          command: bazel test //:test_integration --test_output=errors
+          command: bazel test //:test_concept --test_output=errors
+
+  test-grakn:
+    machine:
+      image: ubuntu-1604:201903-01
+    working_directory: ~/client-python
+    steps:
+      - install-bazel
+      - checkout
+      - run-bazel:
+          command: bazel test //:test_grakn --test_output=errors
+
+  test-keyspace:
+    machine:
+      image: ubuntu-1604:201903-01
+    working_directory: ~/client-python
+    steps:
+      - install-bazel
+      - checkout
+      - run-bazel:
+          command: bazel test //:test_keyspace --test_output=errors
+
+  test-answer:
+    machine:
+      image: ubuntu-1604:201903-01
+    working_directory: ~/client-python
+    steps:
+      - install-bazel
+      - checkout
+      - run-bazel:
+          command: bazel test //:test_answer --test_output=errors
 
   deploy-pip-snapshot:
     machine: 
@@ -180,7 +210,19 @@ workflows:
           filters:
             branches:
               ignore: client-python-release-branch
-      - test:
+      - test-concept:
+          filters:
+            branches:
+              ignore: client-python-release-branch
+      - test-grakn:
+          filters:
+            branches:
+              ignore: client-python-release-branch
+      - test-keyspace:
+          filters:
+            branches:
+              ignore: client-python-release-branch
+      - test-answer:
           filters:
             branches:
               ignore: client-python-release-branch
@@ -190,7 +232,10 @@ workflows:
               only: master
           requires:
             - build
-            - test
+            - test-concept
+            - test-grakn
+            - test-keyspace
+            - test-answer
       - test-deployment:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,7 @@ commands:
   run-grakn:
     steps:
       - run-bazel:
-          command: bazel build @graknlabs_grakn_core//:assemble-linux-targz
-      - run: mkdir dist && tar -xvzf bazel-bin/external/graknlabs_grakn_core/grakn-core-all-linux.tar.gz -C ./dist/
+          command: bazel run //:grakn-extractor -- dist/grakn-core-all-linux
       - run: nohup ./dist/grakn-core-all-linux/grakn server start
 jobs:
   build:

--- a/BUILD
+++ b/BUILD
@@ -27,6 +27,7 @@ load("@graknlabs_bazel_distribution_pip//:requirements.bzl",
        graknlabs_bazel_distribution_requirement = "requirement")
 
 load("@graknlabs_bazel_distribution//github:rules.bzl", "deploy_github")
+load("@graknlabs_dependencies//distribution/artifact:rules.bzl", "artifact_extractor")
 
 
 py_library(
@@ -150,4 +151,9 @@ test_suite(
         ":test_keyspace",
         ":test_answer",
     ]
+)
+
+artifact_extractor(
+    name = "grakn-extractor",
+    artifact = "@graknlabs_grakn_core_artifact//file",
 )

--- a/BUILD
+++ b/BUILD
@@ -94,7 +94,8 @@ py_test(
     deps = [
         ":client_python",
     ],
-    data = ["@graknlabs_grakn_core//:assemble-mac-zip"],
+    data = ["@graknlabs_grakn_core_artifact//file"],
+    args = ["$(location @graknlabs_grakn_core_artifact//file)"],
     python_version = "PY3"
 )
 
@@ -107,7 +108,8 @@ py_test(
     deps = [
         ":client_python",
     ],
-    data = ["@graknlabs_grakn_core//:assemble-mac-zip"],
+    data = ["@graknlabs_grakn_core_artifact//file"],
+    args = ["$(location @graknlabs_grakn_core_artifact//file)"],
     python_version = "PY3"
 )
 
@@ -120,7 +122,8 @@ py_test(
     deps = [
         ":client_python",
     ],
-    data = ["@graknlabs_grakn_core//:assemble-mac-zip"],
+    data = ["@graknlabs_grakn_core_artifact//file"],
+    args = ["$(location @graknlabs_grakn_core_artifact//file)"],
     python_version = "PY3"
 )
 
@@ -134,7 +137,8 @@ py_test(
         ":client_python",
     ],
     size = "large",
-    data = ["@graknlabs_grakn_core//:assemble-mac-zip"],
+    data = ["@graknlabs_grakn_core_artifact//file"],
+    args = ["$(location @graknlabs_grakn_core_artifact//file)"],
     python_version = "PY3"
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,7 +20,7 @@ workspace(name = "graknlabs_client_python")
 ################################
 # Load @graknlabs_dependencies #
 ################################
-load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_dependencies")
+load("//dependencies/graknlabs:repositories.bzl", "graknlabs_dependencies")
 graknlabs_dependencies()
 
 # Load Antlr
@@ -131,7 +131,7 @@ rules_pkg_dependencies()
 ############################
 # Load @graknlabs_protocol #
 ############################
-load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_protocol")
+load("//dependencies/graknlabs:repositories.bzl", "graknlabs_protocol")
 graknlabs_protocol()
 
 load("@graknlabs_dependencies//builder/grpc:deps.bzl", grpc_deps = "deps")
@@ -144,48 +144,11 @@ com_github_grpc_grpc_deps()
 load("@stackb_rules_proto//java:deps.bzl", "java_grpc_compile")
 java_grpc_compile()
 
-##############################
-# Load @graknlabs_grakn_core #
-##############################
-load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_grakn_core")
-graknlabs_grakn_core()
-
-load("@graknlabs_grakn_core//dependencies/maven:dependencies.bzl",
-graknlabs_grakn_core_maven_dependencies = "maven_dependencies")
-graknlabs_grakn_core_maven_dependencies()
-
-#######################################################
-# Load @graknlabs_common (from @graknlabs_grakn_core) #
-#######################################################
-load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl", "graknlabs_common")
-graknlabs_common()
-
-######################################################
-# Load @graknlabs_graql (from @graknlabs_grakn_core) #
-######################################################
-load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl", "graknlabs_graql")
-graknlabs_graql()
-load("@graknlabs_graql//dependencies/maven:artifacts.bzl", graknlabs_graql_artifacts = "artifacts")
-
-##############################################################
-# Load @graknlabs_grabl_tracing (from @graknlabs_grakn_core) #
-##############################################################
-load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl", "graknlabs_grabl_tracing")
-graknlabs_grabl_tracing()
-load("@graknlabs_grabl_tracing//dependencies/maven:artifacts.bzl", graknlabs_grabl_tracing_artifacts = "artifacts")
-
-############################################################
-# Load @graknlabs_client_java (from @graknlabs_grakn_core) #
-############################################################
-load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl", "graknlabs_client_java")
-graknlabs_client_java()
-load("@graknlabs_client_java//dependencies/maven:artifacts.bzl", graknlabs_client_java_artifacts = "artifacts")
-
-########################################################
-# Load @graknlabs_console (from @graknlabs_grakn_core) #
-########################################################
-load("@graknlabs_grakn_core//dependencies/graknlabs:dependencies.bzl", "graknlabs_console")
-graknlabs_console()
+#######################################
+# Load @graknlabs_grakn_core_artifact #
+#######################################
+load("//dependencies/graknlabs:artifacts.bzl", "graknlabs_grakn_core_artifact")
+graknlabs_grakn_core_artifact()
 
 #################################
 # Load @graknlabs_client_python #
@@ -197,12 +160,3 @@ pip3_import(
 load("@graknlabs_client_python_pip//:requirements.bzl",
 graknlabs_client_python_pip_install = "pip_install")
 graknlabs_client_python_pip_install()
-
-###############
-# Load @maven #
-###############
-maven(
-    graknlabs_graql_artifacts +
-    graknlabs_grabl_tracing_artifacts +
-    graknlabs_client_java_artifacts
-)

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -14,3 +14,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+
+load("@graknlabs_dependencies//distribution/artifact:rules.bzl", "artifact_file")
+
+def graknlabs_grakn_core_artifact():
+    artifact_file(
+        name = "graknlabs_grakn_core_artifact",
+        group_name = "graknlabs_grakn_core",
+        artifact_name = "grakn-core-all-linux-{version}.tar.gz",
+        commit = "7cc0fcc8e44eb419f540b5ccedb4fcfe23c26e32",
+    )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -21,7 +21,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "cb766fa6f38452aedc1a30c838c7621701b3bada",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "504561c1343b12cfb08cd65c25155045da0b709e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_protocol():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -21,14 +21,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "61fe8156b640196b4673fdf4f84075655bc0bc61",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
-    )
-
-def graknlabs_grakn_core():
-    git_repository(
-        name = "graknlabs_grakn_core",
-        remote = "https://github.com/graknlabs/grakn",
-        commit = "553cde5dda0d714a86c07b55c5c801a3d315838a" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "cb766fa6f38452aedc1a30c838c7621701b3bada",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_protocol():

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -19,26 +19,13 @@
 from __future__ import print_function
 
 from unittest import TestCase
-from datetime import datetime
 
 import os
 import shutil
-import six
 import subprocess as sp
 import tempfile
-# import zipfile
 import sys
 import tarfile
-
-
-# class ZipFile(zipfile.ZipFile):
-#     def _extract_member(self, member, targetpath, pwd):
-#         if not isinstance(member, zipfile.ZipInfo):
-#             member = self.getinfo(member)
-#         ret_val = super()._extract_member(member, targetpath, pwd)
-#         attr = member.external_attr >> 16
-#         os.chmod(ret_val, attr)
-#         return ret_val
 
 
 class GraknServer(object):
@@ -65,7 +52,7 @@ class GraknServer(object):
         self.__unpacked_dir = tempfile.mkdtemp(prefix='grakn')
         with tarfile.open(GraknServer.DISTRIBUTION_LOCATION) as tf:
             tf.extractall(self.__unpacked_dir)
-            self.__distribution_root_dir = os.path.commonpath(tf.getnames())
+            self.__distribution_root_dir = os.path.commonpath(tf.getnames()[1:])
 
 
 class test_Base(TestCase):

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -26,24 +26,26 @@ import shutil
 import six
 import subprocess as sp
 import tempfile
-import zipfile
+# import zipfile
+import sys
+import tarfile
 
 
-class ZipFile(zipfile.ZipFile):
-    def _extract_member(self, member, targetpath, pwd):
-        if not isinstance(member, zipfile.ZipInfo):
-            member = self.getinfo(member)
-        ret_val = super()._extract_member(member, targetpath, pwd)
-        attr = member.external_attr >> 16
-        os.chmod(ret_val, attr)
-        return ret_val
+# class ZipFile(zipfile.ZipFile):
+#     def _extract_member(self, member, targetpath, pwd):
+#         if not isinstance(member, zipfile.ZipInfo):
+#             member = self.getinfo(member)
+#         ret_val = super()._extract_member(member, targetpath, pwd)
+#         attr = member.external_attr >> 16
+#         os.chmod(ret_val, attr)
+#         return ret_val
 
 
 class GraknServer(object):
-    DISTRIBUTION_LOCATION = 'external/graknlabs_grakn_core/grakn-core-all-mac.zip'
-    DISTRIBUTION_ROOT_DIR = 'grakn-core-all-mac'
+    DISTRIBUTION_LOCATION = sys.argv.pop()
 
     def __init__(self):
+        self.__distribution_root_dir = None
         self.__unpacked_dir = None
 
     def __enter__(self):
@@ -51,18 +53,19 @@ class GraknServer(object):
             self._unpack()
         sp.check_call([
             'grakn', 'server', 'start'
-        ], cwd=os.path.join(self.__unpacked_dir, GraknServer.DISTRIBUTION_ROOT_DIR))
+        ], cwd=os.path.join(self.__unpacked_dir, self.__distribution_root_dir))
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         sp.check_call([
             'grakn', 'server', 'stop'
-        ], cwd=os.path.join(self.__unpacked_dir, GraknServer.DISTRIBUTION_ROOT_DIR))
+        ], cwd=os.path.join(self.__unpacked_dir, self.__distribution_root_dir))
         shutil.rmtree(self.__unpacked_dir)
 
     def _unpack(self):
         self.__unpacked_dir = tempfile.mkdtemp(prefix='grakn')
-        with ZipFile(GraknServer.DISTRIBUTION_LOCATION) as zf:
-            zf.extractall(self.__unpacked_dir)
+        with tarfile.open(GraknServer.DISTRIBUTION_LOCATION) as tf:
+            tf.extractall(self.__unpacked_dir)
+            self.__distribution_root_dir = os.path.commonpath(tf.getnames())
 
 
 class test_Base(TestCase):


### PR DESCRIPTION
## What is the goal of this PR?

Client-java does not depend on grakn core to build, only to test. By depending on the new artifact distribution, we can eliminate many bazel workspace dependencies that may cause consistency issues during tests.

We also need to change the CI to run jobs in parallel because right now they are unable to run the test suite without relying on RBE to provide isolation for each sub-test.

## What are the changes implemented in this PR?

- Removed grakn core dependencies
- Updated to new dependencies form
- Depend on grakn core as artifact
- Rework test framework to use the artifact form
- Split tests in CI