### PR TITLE
Build remotely on Ubuntu 20.04

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,29 +4,12 @@ test --incompatible_strict_action_env
 
 # what is defined in this section will be applied when bazel is invoked like this: bazel ... --config=rbe ...
 build:rbe --project_id=grakn-dev
-build:rbe --remote_instance_name=projects/grakn-dev/instances/default_instance
 build:rbe --remote_cache=cloud.buildbuddy.io
 build:rbe --remote_executor=cloud.buildbuddy.io
 build:rbe --bes_backend=cloud.buildbuddy.io
 build:rbe --bes_results_url=https://app.buildbuddy.io/invocation/
-build:rbe --tls_client_certificate=/opt/.credentials/buildbuddy-cert.pem
-build:rbe --tls_client_key=/opt/.credentials/buildbuddy-key.pem
-build:rbe --host_platform=@graknlabs_dependencies//image/rbe:ubuntu-1604
-build:rbe --platforms=@graknlabs_dependencies//image/rbe:ubuntu-1604
-build:rbe --extra_execution_platforms=@graknlabs_dependencies//image/rbe:ubuntu-1604
-build:rbe --host_javabase=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/bazel_3.0.0/java:jdk
-build:rbe --javabase=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/bazel_3.0.0/java:jdk
-build:rbe --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build:rbe --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build:rbe --extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/bazel_3.0.0/config:cc-toolchain
-build:rbe --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/bazel_3.0.0/cc:toolchain
+build:rbe --tls_client_certificate=/opt/credentials/buildbuddy-cert.pem
+build:rbe --tls_client_key=/opt/credentials/buildbuddy-key.pem
+build:rbe --host_platform=@graknlabs_dependencies//image/buildbuddy:ubuntu-2004
 build:rbe --jobs=50
 build:rbe --remote_timeout=3600
-build:rbe --bes_timeout=600s
-build:rbe --spawn_strategy=remote
-build:rbe --strategy=Javac=remote
-build:rbe --strategy=Closure=remote
-build:rbe --genrule_strategy=remote
-build:rbe --define=EXECUTOR=remote
-build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-build:rbe --experimental_strict_action_env=true

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -7,10 +7,7 @@ build:
       machine: graknlabs-ubuntu-20.04
       type: foreground
       script: |
-        pyenv global 3.6.10
-        sudo unlink /usr/bin/python3
-        sudo ln -s $(which python3) /usr/bin/python3
-        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.6.10/lib/python3.6/site-packages/lsb_release.py
+        pyenv global system
         ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME \
         ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD \
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
@@ -19,10 +16,7 @@ build:
       machine: graknlabs-ubuntu-20.04
       type: foreground
       script: |
-        pyenv global 3.6.10
-        sudo unlink /usr/bin/python3
-        sudo ln -s $(which python3) /usr/bin/python3
-        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.6.10/lib/python3.6/site-packages/lsb_release.py
+        pyenv global system
         ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME \
         ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD \
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
@@ -31,10 +25,7 @@ build:
       machine: graknlabs-ubuntu-20.04
       type: foreground
       script: |
-        pyenv global 3.6.10
-        sudo unlink /usr/bin/python3
-        sudo ln -s $(which python3) /usr/bin/python3
-        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.6.10/lib/python3.6/site-packages/lsb_release.py
+        pyenv global system
         ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME \
         ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD \
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
@@ -43,10 +34,7 @@ build:
       machine: graknlabs-ubuntu-20.04
       type: foreground
       script: |
-        pyenv global 3.6.10
-        sudo unlink /usr/bin/python3
-        sudo ln -s $(which python3) /usr/bin/python3
-        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.6.10/lib/python3.6/site-packages/lsb_release.py
+        pyenv global system
         ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME \
         ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD \
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
@@ -58,10 +46,7 @@ build:
       machine: graknlabs-ubuntu-20.04
       type: foreground
       script: |
-        pyenv global 3.6.10
-        sudo unlink /usr/bin/python3
-        sudo ln -s $(which python3) /usr/bin/python3
-        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.6.10/lib/python3.6/site-packages/lsb_release.py
+        pyenv global system
         ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME \
         ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD \
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
@@ -76,10 +61,7 @@ build:
       type: foreground
       dependencies: [deploy-pip-snapshot]
       script: |
-        pyenv global 3.6.10
-        sudo unlink /usr/bin/python3
-        sudo ln -s $(which python3) /usr/bin/python3
-        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.6.10/lib/python3.6/site-packages/lsb_release.py
+        pyenv global system
         ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME \
         ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD \
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
@@ -113,10 +95,7 @@ release:
     deploy-github:
       machine: graknlabs-ubuntu-20.04
       script: |
-        pyenv global 3.6.10
-        sudo unlink /usr/bin/python3
-        sudo ln -s $(which python3) /usr/bin/python3
-        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.6.10/lib/python3.6/site-packages/lsb_release.py
+        pyenv global system
         pip install certifi
         export RELEASE_NOTES_TOKEN=$REPO_GITHUB_TOKEN
         bazel run @graknlabs_dependencies//tool/release:create-notes -- client-python $(cat VERSION) ./RELEASE_TEMPLATE.md
@@ -126,10 +105,7 @@ release:
     deploy-pip-release:
       machine: graknlabs-ubuntu-20.04
       script: |
-        pyenv global 3.6.10
-        sudo unlink /usr/bin/python3
-        sudo ln -s $(which python3) /usr/bin/python3
-        sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.6.10/lib/python3.6/site-packages/lsb_release.py
+        pyenv global system
         export DEPLOY_PIP_USERNAME=$REPO_PYPI_USERNAME
         export DEPLOY_PIP_PASSWORD=$REPO_PYPI_PASSWORD
         bazel run --define version=$(cat VERSION) //:deploy-pip -- release

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -14,7 +14,7 @@ build:
         ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME \
         ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD \
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-        bazel build //...
+        bazel build --config=rbe //...
     test-concept:
       machine: graknlabs-ubuntu-20.04
       type: foreground
@@ -26,7 +26,7 @@ build:
         ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME \
         ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD \
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-        bazel test //:test_concept --test_output=errors
+        bazel test --config=rbe //:test_concept --test_output=errors
     test-keyspace:
       machine: graknlabs-ubuntu-20.04
       type: foreground
@@ -38,7 +38,7 @@ build:
         ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME \
         ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD \
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-        bazel test //:test_keyspace --test_output=errors
+        bazel test --config=rbe //:test_keyspace --test_output=errors
     test-answer:
       machine: graknlabs-ubuntu-20.04
       type: foreground
@@ -50,7 +50,7 @@ build:
         ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME \
         ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD \
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-        bazel test //:test_answer --test_output=errors
+        bazel test --config=rbe //:test_answer --test_output=errors
     deploy-pip-snapshot:
       filter:
         owner: graknlabs

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -21,7 +21,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "1c86421327bec68a83c3f88d728add07010f797a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "172e16ed56a83ff4c9815b1ebcdeea7ddb92860f",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_protocol():


### PR DESCRIPTION
## What is the goal of this PR?

In order to speed up our builds, we should do them remotely on BuildBuddy

## What are the changes implemented in this PR?

Tweak `.bazelrc` settings to build on BuildBuddy with our own Ubuntu 20.04 image