### PR TITLE
Update how we pass requirements to assemble_pip

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -79,12 +79,7 @@ assemble_pip(
     author = "Grakn Labs",
     author_email = "community@grakn.ai",
     license = "Apache-2.0",
-    install_requires=[
-        'graknprotocol==2.0.0a4',
-        'grpcio==1.33.2',
-        'protobuf==3.6.1',
-        'six>=1.11.0',
-    ],
+    requirements_file = "//:requirements.txt",
     keywords = ["grakn", "database", "graph", "knowledgebase", "knowledge-engineering"],
     description = "Grakn Client for Python",
     long_description_file = "//:README.md",

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -23,7 +23,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "ed2c074bea897dada26e4f112c1d08f739e90012",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "0989c45b00a80eef83f2caa278961dd0d7fd0b76",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_common():


### PR DESCRIPTION
## What is the goal of this PR?

Recently, we've upgraded how Python package dependencies are passed to `assemble_pip` rule. Therefore, all usages of `assemble_pip` need to be updated.

## What are the changes implemented in this PR?

Pass `requirements.txt` to `assemble_pip`