### PR TITLE
Validate Python dependencies before releasing

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -132,11 +132,10 @@ release:
   filter:
     owner: graknlabs
     branch: master
-  # TODO: add it back once we're able to depend on @graknlabs_protocol as bazel rather than artifact dependency
-  #  validation:
-  #    validate-dependencies:
-  #      image: graknlabs-ubuntu-20.04
-  #      script: bazel test //:release-validate-deps --test_output=streamed
+  validation:
+    validate-dependencies:
+      image: graknlabs-ubuntu-20.04
+      script: bazel test //:release-validate-python-deps --test_output=streamed
   deployment:
     deploy-github:
       image: graknlabs-ubuntu-20.04

--- a/BUILD
+++ b/BUILD
@@ -27,7 +27,7 @@ load("@graknlabs_bazel_distribution_pip//:requirements.bzl", graknlabs_bazel_dis
 load("@graknlabs_bazel_distribution//github:rules.bzl", "deploy_github")
 load("@graknlabs_bazel_distribution//artifact:rules.bzl", "artifact_extractor")
 
-load("@graknlabs_dependencies//tool/release:rules.bzl", "release_validate_deps")
+load("@graknlabs_dependencies//tool/release:rules.bzl", "release_validate_python_deps")
 load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 load("@graknlabs_dependencies//distribution:deployment.bzl", "deployment")
 load(":deployment.bzl", github_deployment = "deployment")
@@ -109,15 +109,13 @@ artifact_extractor(
     artifact = "@graknlabs_grakn_core_artifact_linux//file",
 )
 
-# TODO: add it back once we're able to depend on @graknlabs_protocol as bazel rather than artifact dependency
-#release_validate_deps(
-#    name = "release-validate-deps",
-#    refs = "@graknlabs_client_python_workspace_refs//:refs.json",
-#    tagged_deps = [
-#        "@graknlabs_protocol",
-#    ],
-#    tags = ["manual"]  # in order for bazel test //... to not fail
-#)
+release_validate_python_deps(
+    name = "release-validate-python-deps",
+    requirements = "//:requirements.txt",
+    tagged_deps = [
+        "graknprotocol",
+    ],
+)
 
 # CI targets that are not declared in any BUILD file, but are called externally
 filegroup(

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -23,7 +23,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "0989c45b00a80eef83f2caa278961dd0d7fd0b76",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "bec7e4103069a08384f32bc1d3bc8e17ff5f5af0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_common():


### PR DESCRIPTION
## What is the goal of this PR?

Currently, there's no validation happening before the release. We should validate that the version of `graknprotocol` is available on PyPI with newly-developed `release_validate_python_deps`

## What are the changes implemented in this PR?

- Upgrade `@graknlabs_dependencies`
- Add `//:release-validate-python-deps`
