### PR TITLE
Update usage of native_artifact_files

### DIFF
--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -24,8 +24,8 @@ def graknlabs_grakn_core_artifacts():
     native_artifact_files(
         name = "graknlabs_grakn_core_artifact",
         group_name = "graknlabs_grakn_core",
-        artifact_name = "grakn-core-server-{platform}-{version}.tar.gz",
+        artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "8e80542cd6afe3318859320565e8afe119e7ae11",
+        commit = "81653e39fa681d20b37fdba13f158a0d1c1a6c2e",
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -23,7 +23,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "bec7e4103069a08384f32bc1d3bc8e17ff5f5af0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "b6ddf3ee17d91df9bbed294392d0adba5737da44",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_common():


### PR DESCRIPTION
## What is the goal of this PR?

We need to update the usage of `native_artifact_files` to account for different artifact file extensions (`.tar.gz` vs `.zip`)

## What are the changes implemented in this PR?

* Use templated extension in `native_artifact_files`
* Bump `@graknlabs_dependencies`
* Bump `@graknlabs_grakn_core_artifact`