### PR TITLE
API cleanup: close on commit, isX methods

### DIFF
--- a/grakn/concept/concept.py
+++ b/grakn/concept/concept.py
@@ -23,7 +23,31 @@ class Concept(object):
     def is_type(self):
         return False
 
+    def is_thing_type(self):
+        return False
+
+    def is_entity_type(self):
+        return False
+
+    def is_attribute_type(self):
+        return False
+
+    def is_relation_type(self):
+        return False
+
+    def is_role_type(self):
+        return False
+
     def is_thing(self):
+        return False
+
+    def is_entity(self):
+        return False
+
+    def is_attribute(self):
+        return False
+
+    def is_relation(self):
         return False
 
     def is_remote(self):
@@ -44,5 +68,29 @@ class RemoteConcept(object):
     def is_type(self):
         return False
 
+    def is_thing_type(self):
+        return False
+
+    def is_entity_type(self):
+        return False
+
+    def is_attribute_type(self):
+        return False
+
+    def is_relation_type(self):
+        return False
+
+    def is_role_type(self):
+        return False
+
     def is_thing(self):
+        return False
+
+    def is_entity(self):
+        return False
+
+    def is_attribute(self):
+        return False
+
+    def is_relation(self):
         return False

--- a/grakn/concept/thing/thing.py
+++ b/grakn/concept/thing/thing.py
@@ -41,15 +41,6 @@ class Thing(Concept):
     def is_thing(self):
         return True
 
-    def is_entity(self):
-        return False
-
-    def is_attribute(self):
-        return False
-
-    def is_relation(self):
-        return False
-
     def __str__(self):
         return type(self).__name__ + "[iid:" + self.get_iid() + "]"
 
@@ -141,15 +132,6 @@ class RemoteThing(RemoteConcept):
 
     def is_thing(self):
         return True
-
-    def is_entity(self):
-        return False
-
-    def is_attribute(self):
-        return False
-
-    def is_relation(self):
-        return False
 
     def _thing_stream(self, method: concept_proto.Thing.Req, thing_list_getter: Callable[[concept_proto.Thing.Res], List[concept_proto.Thing]]):
         method.iid = concept_proto_builder.iid(self.get_iid())

--- a/grakn/concept/type/relation_type.py
+++ b/grakn/concept/type/relation_type.py
@@ -75,3 +75,6 @@ class RemoteRelationType(RemoteThingType):
         unset_relates_req.label = role_label
         method.relation_type_unset_relates_req.CopyFrom(unset_relates_req)
         self._execute(method)
+
+    def is_relation_type(self):
+        return True

--- a/grakn/concept/type/thing_type.py
+++ b/grakn/concept/type/thing_type.py
@@ -28,6 +28,9 @@ class ThingType(Type):
     def as_remote(self, transaction):
         return RemoteThingType(transaction, self.get_label(), self.is_root())
 
+    def is_thing_type(self):
+        return True
+
 
 class RemoteThingType(RemoteType):
 

--- a/grakn/concept/type/type.py
+++ b/grakn/concept/type/type.py
@@ -45,21 +45,6 @@ class Type(Concept):
     def is_type(self):
         return True
 
-    def is_thing_type(self):
-        return False
-
-    def is_entity_type(self):
-        return False
-
-    def is_attribute_type(self):
-        return False
-
-    def is_relation_type(self):
-        return False
-
-    def is_role_type(self):
-        return False
-
     def __str__(self):
         return type(self).__name__ + "[label:" + self.get_label() + "]"
 
@@ -109,21 +94,6 @@ class RemoteType(RemoteConcept):
 
     def is_type(self):
         return True
-
-    def is_thing_type(self):
-        return False
-
-    def is_entity_type(self):
-        return False
-
-    def is_attribute_type(self):
-        return False
-
-    def is_relation_type(self):
-        return False
-
-    def is_role_type(self):
-        return False
 
     def set_supertype(self, _type: Type):
         req = concept_proto.Type.Req()

--- a/grakn/rpc/transaction.py
+++ b/grakn/rpc/transaction.py
@@ -89,7 +89,10 @@ class Transaction(object):
         req = transaction_proto.Transaction.Req()
         commit_req = transaction_proto.Transaction.Commit.Req()
         req.commit_req.CopyFrom(commit_req)
-        self._execute(req)
+        try:
+            self._execute(req)
+        finally:
+            self.close()
 
     def rollback(self):
         req = transaction_proto.Transaction.Req()


### PR DESCRIPTION
## What is the goal of this PR?

As we close transactions on commit at the server end, it makes sense to also close transactions when they are committed at client side. This change does that. Additionally, for user experience reasons, "isX" functions have been added to the Concept interface to determine what variety of Concept an object represents.

## What are the changes implemented in this PR?

We added a try/finally to `commit()` that closes the transaction when it completes or fails.
We added is[Concept] functions to all Concepts indicating if the current Concept is an instance of that Concept variety.