### PR TITLE
Update automation.yml to include `release` dependency for `common`

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -21,7 +21,7 @@ config:
   version-candidate: VERSION
   dependencies:
     dependencies: [build]
-    common: [build] # TODO: add 'release' once dependency-analysis works with tags
+    common: [build, release]
 
 build:
   quality:


### PR DESCRIPTION
## What is the goal of this PR?

Re-add 'release' to 'common' dependency, since dependency-analysis is supporting tags now.