### PR TITLE
Update automation.yml to include `behaviour` dependency

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -22,6 +22,7 @@ config:
   dependencies:
     dependencies: [build]
     common: [build, release]
+    behaviour: [build]
 
 build:
   quality:


### PR DESCRIPTION
## What is the goal of this PR?

Following https://github.com/graknlabs/client-python/pull/154 PR, dependency analysis showed that `behaviour` repo is not defined in dependencies of automation.yml
