### PR TITLE
Update dependency on grakn-protocol

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -37,7 +37,7 @@ py_library(
     name = "client_python",
     srcs = glob(["grakn/**/*.py"]),
     deps = [
-        graknlabs_client_python_requirement("graknprotocol"),
+        graknlabs_client_python_requirement("grakn-protocol"),
         graknlabs_client_python_requirement("protobuf"),
         graknlabs_client_python_requirement("grpcio"),
         graknlabs_client_python_requirement("six"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,8 @@
 
 ## Configuration options
 
-# --extra-index-url https://repo.grakn.ai/repository/pypi-snapshot/simple  # Allow importing of snapshots
+# Uncomment next line to allow importing of snapshots
+# --extra-index-url https://repo.grakn.ai/repository/pypi-snapshot/simple
 
 
 ## Dependencies

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -19,12 +19,13 @@
 
 ## Configuration options
 
-# --extra-index-url https://repo.grakn.ai/repository/pypi-snapshot/simple  # Allow importing of snapshots
+# Uncomment next line to allow importing of snapshots
+--extra-index-url https://repo.grakn.ai/repository/pypi-snapshot/simple
 
 
 ## Dependencies
 
-graknprotocol==2.0.0a5
+grakn-protocol==0.0.0-fbebfee7e515ddec4266cce44848b9933fdaf787
 grpcio==1.33.2
 protobuf==3.6.1
 six>=1.11.0


### PR DESCRIPTION
## What is the goal of this PR?

Depend on Grakn Protocol package by the new name `grakn-protocol` (consistent across all platforms)

# What are the changes implemented in this PR?

graknlabs/protocol#106 renamed Protocol package deployed to PyPI to `grakn-protocol`. In this PR dependency is upgraded to latest `snapshot` version of `grakn-protocol`.
