### PR TITLE
Add ability to retrieve all rules

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -107,7 +107,7 @@ release_validate_python_deps(
     name = "release-validate-python-deps",
     requirements = "//:requirements.txt",
     tagged_deps = [
-        "graknprotocol",
+        "grakn-protocol",
     ],
 )
 

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -23,7 +23,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "f40b54f36acc91f1ef089058773ec0304dc38ce8",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "ca7d021093fe1308b7da52d45809bf06a1d95bc6",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_common():

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,13 +19,13 @@
 
 ## Configuration options
 
-# Uncomment next line to allow importing of snapshots
-# --extra-index-url https://repo.grakn.ai/repository/pypi-snapshot/simple
+# Allow importing of snapshots
+--extra-index-url https://repo.grakn.ai/repository/pypi-snapshot/simple
 
 
 ## Dependencies
 
-graknprotocol==2.0.0a5
+grakn-protocol==0.0.0-3b8f0d6dc7cd176e59b13e447c64ba41a2ecff7e
 grpcio==1.33.2
 protobuf==3.6.1
 six>=1.11.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -19,13 +19,13 @@
 
 ## Configuration options
 
-# Uncomment next line to allow importing of snapshots
+# Allow importing of snapshots
 --extra-index-url https://repo.grakn.ai/repository/pypi-snapshot/simple
 
 
 ## Dependencies
 
-grakn-protocol==0.0.0-fbebfee7e515ddec4266cce44848b9933fdaf787
+grakn-protocol==0.0.0-3b8f0d6dc7cd176e59b13e447c64ba41a2ecff7e
 grpcio==1.33.2
 protobuf==3.6.1
 six>=1.11.0


### PR DESCRIPTION
## What is the goal of this PR?

Since Rule was refactored in Grakn 2.0 to no longer be a subtype of Concept, we lost the ability to retrieve all rules using `match $x sub rule; get;`.

So, to allow the user to retrieve all rules, we now add `get_rules` to the `LogicManager`, enabling use of `tx().logic().get_rules()`.

## What are the changes implemented in this PR?

Add get_rules to LogicManager