### PR TITLE
Remove dependency on six library

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -40,7 +40,6 @@ py_library(
         graknlabs_client_python_requirement("grakn-protocol"),
         graknlabs_client_python_requirement("protobuf"),
         graknlabs_client_python_requirement("grpcio"),
-        graknlabs_client_python_requirement("six"),
     ],
     visibility = ["//visibility:public"]
 )

--- a/grakn/rpc/stream.py
+++ b/grakn/rpc/stream.py
@@ -19,14 +19,12 @@
 
 from typing import Callable, List
 
-import six
-
 import graknprotocol.protobuf.transaction_pb2 as transaction_proto
 
 from grakn.common.exception import GraknClientException
 
 
-class Stream(six.Iterator):
+class Stream:
 
     _CONTINUE = "continue"
     _DONE = "done"

--- a/grakn/rpc/transaction.py
+++ b/grakn/rpc/transaction.py
@@ -21,11 +21,10 @@ import enum
 from typing import Callable, List
 
 import grpc
-import six
 import time
 import uuid
 
-from six.moves import queue
+import queue
 
 from graknprotocol.protobuf.grakn_pb2_grpc import GraknStub
 import graknprotocol.protobuf.transaction_pb2 as transaction_proto
@@ -172,7 +171,7 @@ class Transaction:
             return transaction_proto.Transaction.Type.Value("WRITE")
 
 
-class RequestIterator(six.Iterator):
+class RequestIterator:
     CLOSE_STREAM = "CLOSE_STREAM"
 
     def __init__(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,3 @@
 graknprotocol==2.0.0a5
 grpcio==1.33.2
 protobuf==3.6.1
-six>=1.11.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -28,7 +28,6 @@
 grakn-protocol==0.0.0-fbebfee7e515ddec4266cce44848b9933fdaf787
 grpcio==1.33.2
 protobuf==3.6.1
-six>=1.11.0
 
 
 # Dev dependencies (not required to use the grakn-client package, but necessary for its development)


### PR DESCRIPTION
## What is the goal of this PR?

As Grakn Client Python is a Python 3-only library, we no longer need to depend on `six` library (which is a compatibility layer between Python 2 and Python 3) and therefore it needs to be removed for better code maintainability and understandability.

## What are the changes implemented in this PR?

Fix #159

* Remove `six` imports from everywhere
* `six.Iterator` is replaced with nothing (as it's aliased to `object` when running under Python 3)
* `six.moves.queue` is replaces with `queue` (native Python 3 dependency)
