### PR TITLE
Fix console warnings caused by out of date dependency

### DIFF
--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,5 +27,5 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "184f37fcd48cc55ef15a7425bc863b18071afc35",
+        commit = "7644c0194f3e9ba7cee1a3b8964a67086472165d",
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -23,7 +23,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "f40b54f36acc91f1ef089058773ec0304dc38ce8",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "ca7d021093fe1308b7da52d45809bf06a1d95bc6",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_common():

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,12 +20,12 @@
 ## Configuration options
 
 # Uncomment next line to allow importing of snapshots
-# --extra-index-url https://repo.grakn.ai/repository/pypi-snapshot/simple
+--extra-index-url https://repo.grakn.ai/repository/pypi-snapshot/simple
 
 
 ## Dependencies
 
-graknprotocol==2.0.0a5
+grakn-protocol==0.0.0-dd72ce607c0c3ed91b93f5625afbce6033e82eb7
 grpcio==1.33.2
-protobuf==3.6.1
+protobuf==3.14.0
 six>=1.11.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -25,9 +25,9 @@
 
 ## Dependencies
 
-grakn-protocol==0.0.0-fbebfee7e515ddec4266cce44848b9933fdaf787
+grakn-protocol==0.0.0-dd72ce607c0c3ed91b93f5625afbce6033e82eb7
 grpcio==1.33.2
-protobuf==3.6.1
+protobuf==3.14.0
 six>=1.11.0
 
 


### PR DESCRIPTION
## What is the goal of this PR?

Fix `WARNING: An illegal reflective access operation has occurred` warning caused by an out of date version of protobuf.

## What are the changes implemented in this PR?

- Update protobuf to latest.