### PR TITLE
Reenable remote build caching

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,29 +23,10 @@ test --incompatible_strict_action_env --test_env=PATH
 
 # what is defined in this section will be applied when bazel is invoked like this: bazel ... --config=rbe ...
 build:rbe --project_id=grakn-dev
-build:rbe --remote_instance_name=projects/grakn-dev/instances/default_instance
 build:rbe --remote_cache=cloud.buildbuddy.io
-build:rbe --remote_executor=cloud.buildbuddy.io
 build:rbe --bes_backend=cloud.buildbuddy.io
 build:rbe --bes_results_url=https://app.buildbuddy.io/invocation/
-build:rbe --tls_client_certificate=/opt/.credentials/buildbuddy-cert.pem
-build:rbe --tls_client_key=/opt/.credentials/buildbuddy-key.pem
-build:rbe --host_platform=@graknlabs_dependencies//image/rbe:ubuntu-1604
-build:rbe --platforms=@graknlabs_dependencies//image/rbe:ubuntu-1604
-build:rbe --extra_execution_platforms=@graknlabs_dependencies//image/rbe:ubuntu-1604
-build:rbe --host_javabase=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/bazel_3.0.0/java:jdk
-build:rbe --javabase=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/bazel_3.0.0/java:jdk
-build:rbe --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build:rbe --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build:rbe --extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/bazel_3.0.0/config:cc-toolchain
-build:rbe --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/bazel_3.0.0/cc:toolchain
-build:rbe --jobs=50
+build:rbe --tls_client_certificate=/opt/credentials/buildbuddy-cert.pem
+build:rbe --tls_client_key=/opt/credentials/buildbuddy-key.pem
 build:rbe --remote_timeout=3600
-build:rbe --bes_timeout=600s
-build:rbe --spawn_strategy=remote
-build:rbe --strategy=Javac=remote
-build:rbe --strategy=Closure=remote
-build:rbe --genrule_strategy=remote
-build:rbe --define=EXECUTOR=remote
-build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-build:rbe --experimental_strict_action_env=true
+build:rbe --remote_download_minimal

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -42,9 +42,9 @@ build:
         sudo unlink /usr/bin/python3
         sudo ln -s $(which python3) /usr/bin/python3
         sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.6.10/lib/python3.6/site-packages/lsb_release.py
-        bazel build //...
-        bazel run @graknlabs_dependencies//tool/checkstyle:test-coverage
-        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
+        bazel build --config=rbe //...
+        bazel run --config=rbe @graknlabs_dependencies//tool/checkstyle:test-coverage
+        bazel test --config=rbe $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
     test-behaviour:
       image: graknlabs-ubuntu-20.04
       type: foreground
@@ -54,11 +54,11 @@ build:
         sudo unlink /usr/bin/python3
         sudo ln -s $(which python3) /usr/bin/python3
         sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.6.10/lib/python3.6/site-packages/lsb_release.py
-        bazel test //tests/behaviour/connection/... --test_output=errors --jobs=1
-        bazel test //tests/behaviour/concept/... --test_output=errors --jobs=1
-        bazel test //tests/behaviour/graql/language/match/... --test_output=errors --jobs=1
-        bazel test //tests/behaviour/graql/language/get/... --test_output=errors --jobs=1
-        bazel test //tests/behaviour/graql/language/define/... --test_output=errors --jobs=1
+        bazel test --config=rbe //tests/behaviour/connection/... --test_output=errors --jobs=1
+        bazel test --config=rbe //tests/behaviour/concept/... --test_output=errors --jobs=1
+        bazel test --config=rbe //tests/behaviour/graql/language/match/... --test_output=errors --jobs=1
+        bazel test --config=rbe //tests/behaviour/graql/language/get/... --test_output=errors --jobs=1
+        bazel test --config=rbe //tests/behaviour/graql/language/define/... --test_output=errors --jobs=1
       # TODO: remove --jobs=1 from Concept and Graql tests once Grakn runner is parallelisable
     deploy-pip-snapshot:
       image: graknlabs-ubuntu-20.04
@@ -74,7 +74,7 @@ build:
         sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.6.10/lib/python3.6/site-packages/lsb_release.py
         export DEPLOY_PIP_USERNAME=$REPO_GRAKN_USERNAME
         export DEPLOY_PIP_PASSWORD=$REPO_GRAKN_PASSWORD
-        bazel run --define version=$(git rev-parse HEAD) //:deploy-pip -- snapshot
+        bazel run --config=rbe --define version=$(git rev-parse HEAD) //:deploy-pip -- snapshot
     test-deployment-pip:
       image: graknlabs-ubuntu-20.04
       dependencies: [deploy-pip-snapshot]
@@ -116,7 +116,7 @@ release:
         bazel run @graknlabs_dependencies//tool/release:create-notes -- client-python $(cat VERSION) ./RELEASE_TEMPLATE.md
         bazel clean --expunge
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
-        bazel run --define version=$(cat VERSION) //:deploy-github -- $GRABL_COMMIT
+        bazel run --config=rbe --define version=$(cat VERSION) //:deploy-github -- $GRABL_COMMIT
     deploy-pip-release:
       image: graknlabs-ubuntu-20.04
       command: |
@@ -126,5 +126,5 @@ release:
         sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.6.10/lib/python3.6/site-packages/lsb_release.py
         export DEPLOY_PIP_USERNAME=$REPO_PYPI_USERNAME
         export DEPLOY_PIP_PASSWORD=$REPO_PYPI_PASSWORD
-        bazel run --define version=$(cat VERSION) //:deploy-pip -- release
+        bazel run --config=rbe --define version=$(cat VERSION) //:deploy-pip -- release
       dependencies: [deploy-github]


### PR DESCRIPTION
## What is the goal of this PR?

Speed up builds by utilizing remote caching provided by BuildBuddy.

## What are the changes implemented in this PR?

Reenable build caching (without remote execution) on all CI jobs