### PR TITLE
Create one gRPC Channel per session and transaction

### DIFF
--- a/grakn/client.py
+++ b/grakn/client.py
@@ -33,7 +33,8 @@ class GraknClient:
     DEFAULT_URI = "localhost:1729"
 
     def __init__(self, address=DEFAULT_URI):
-        self._channel = grpc.insecure_channel(address)
+        self._address = address
+        self._channel = grpc.insecure_channel(self._address)
         self._databases = _DatabaseManager(self._channel)
         self._is_open = True
 

--- a/grakn/rpc/transaction.py
+++ b/grakn/rpc/transaction.py
@@ -45,14 +45,14 @@ class TransactionType(enum.Enum):
 
 class Transaction:
 
-    def __init__(self, channel: grpc.Channel, session_id: str, transaction_type: TransactionType, options=GraknOptions()):
+    def __init__(self, address: str, session_id: str, transaction_type: TransactionType, options=GraknOptions()):
         self._transaction_type = transaction_type
         self._concept_manager = ConceptManager(self)
         self._query_manager = QueryManager(self)
         self._logic_manager = LogicManager(self)
         self._response_queues = {}
 
-        self._grpc_stub = GraknStub(channel)
+        self._grpc_stub = GraknStub(grpc.insecure_channel(address))
         self._request_iterator = RequestIterator()
         self._response_iterator = self._grpc_stub.transaction(self._request_iterator)
         self._transaction_was_closed = False

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -42,6 +42,17 @@ checkstyle_test(
     size = "small",
 )
 
+py_test(
+    name = "test_concurrent",
+    srcs = [
+        "integration/test_concurrent.py",
+    ],
+    deps = [
+        "//:client_python",
+    ],
+    python_version = "PY3"
+)
+
 artifact_extractor(
     name = "grakn-extractor",
     artifact = ":native-grakn-artifact",

--- a/tests/integration/test_concurrent.py
+++ b/tests/integration/test_concurrent.py
@@ -1,0 +1,60 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import unittest
+from functools import partial
+from multiprocessing.pool import ThreadPool
+from unittest import TestCase
+
+from grakn.client import GraknClient, SessionType, TransactionType
+from grakn.rpc.session import Session
+
+
+class TestConcurrent(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestConcurrent, cls).setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestConcurrent, cls).tearDownClass()
+
+    def setUp(self):
+        pass
+
+    def open_tx(self, session: Session, *args):
+        tx = session.transaction(TransactionType.WRITE)
+        tx.close()
+        self.txs_closed += 1
+        print("Total txs closed: %d" % self.txs_closed)
+
+    def test_open_many_transactions_in_parallel(self):
+        self.txs_closed = 0
+        with GraknClient() as client:
+            with client.session("grakn", SessionType.DATA) as session:
+                pool = ThreadPool(8)
+                results = [None for _ in range(10000)]
+                pool.map(partial(self.open_tx, session), results)
+                pool.close()
+                pool.join()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/integration/test_concurrent.py
+++ b/tests/integration/test_concurrent.py
@@ -28,16 +28,10 @@ from grakn.rpc.session import Session
 
 class TestConcurrent(TestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        super(TestConcurrent, cls).setUpClass()
-
-    @classmethod
-    def tearDownClass(cls):
-        super(TestConcurrent, cls).tearDownClass()
-
     def setUp(self):
-        pass
+        with GraknClient() as client:
+            if "grakn" not in client.databases().all():
+                client.databases().create("grakn")
 
     def open_tx(self, session: Session, *args):
         tx = session.transaction(TransactionType.WRITE)


### PR DESCRIPTION
## What is the goal of this PR?

We observed that when using 2 parallel threads to open a large number of transactions, response messages from the server would be intermittently dropped, leading to the client stalling. Creating a separate gRPC Channel for each transaction appears to solve the issue.

## What are the changes implemented in this PR?

- Create one gRPC Channel per session
- Create one gRPC Channel per transaction
