### PR TITLE
Session pulses reuse threads instead of constructing new ones

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -62,7 +62,6 @@ assemble_pip(
     classifiers = [
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
## What is the goal of this PR?

Reduce the number of threads Client Python spawns for session pulses.
Note: **this change drops support for Python 3.5**.

## What are the changes implemented in this PR?

Fix #158

Use a `ThreadPoolExecutor` to schedule session pulses instead of constructing new threads for every call.