### PR TITLE
Fix 5 second delay before programs using the client actually terminate

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -62,6 +62,7 @@ assemble_pip(
     classifiers = [
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/grakn/rpc/session.py
+++ b/grakn/rpc/session.py
@@ -20,7 +20,7 @@ import enum
 import sched
 import time
 from abc import ABC, abstractmethod
-from concurrent.futures.thread import ThreadPoolExecutor
+from threading import Thread
 
 import grakn_protocol.protobuf.session_pb2 as session_proto
 import grpc
@@ -96,9 +96,10 @@ class _RPCSession(Session):
 
         self._session_id = self._grpc_stub.session_open(open_req).session_id
         self._is_open = True
-        self._pulse_thread_pool = ThreadPoolExecutor(thread_name_prefix='session_pulse_{}'.format(self._session_id.hex()))
-        self._scheduler.enter(delay=self._PULSE_FREQUENCY_SECONDS, priority=1, action=self._transmit_pulse, argument=())
-        self._pulse_thread_pool.submit(self._scheduler.run)
+        self._pulse = self._scheduler.enter(delay=self._PULSE_FREQUENCY_SECONDS, priority=1, action=self._transmit_pulse, argument=())
+        # TODO: This thread blocks the process from closing. We should try cancelling the scheduled task when the
+        #       session closes. If that doesn't work, we need some other way of getting the thread to exit.
+        Thread(target=self._scheduler.run, daemon=True).start()
 
     def transaction(self, transaction_type: TransactionType, options=None) -> Transaction:
         if not options:
@@ -112,7 +113,8 @@ class _RPCSession(Session):
     def close(self) -> None:
         if self._is_open:
             self._is_open = False
-            self._pulse_thread_pool.shutdown(wait=False)
+            self._scheduler.cancel(self._pulse)
+            self._scheduler.empty()
             req = session_proto.Session.Close.Req()
             req.session_id = self._session_id
             try:
@@ -131,10 +133,8 @@ class _RPCSession(Session):
         pulse_req.session_id = self._session_id
         res = self._grpc_stub.session_pulse(pulse_req)
         if res.alive:
-            self._scheduler.enter(delay=self._PULSE_FREQUENCY_SECONDS, priority=1, action=self._transmit_pulse, argument=())
-            self._pulse_thread_pool.submit(self._scheduler.run)
-        else:
-            self._is_open = False
+            self._pulse = self._scheduler.enter(delay=self._PULSE_FREQUENCY_SECONDS, priority=1, action=self._transmit_pulse, argument=())
+            Thread(target=self._scheduler.run, daemon=True).start()
 
     def __enter__(self):
         return self


### PR DESCRIPTION
## What is the goal of this PR?

There was a 5 second delay before programs using Client Python actually terminated, caused by a worker thread staying alive for 5 seconds after closing a Session. We changed the thread to a daemon thread, that does not block the program's termination.

## What are the changes implemented in this PR?

- Use Thread instead of ThreadPoolExecutor for the session pulse scheduler
