### PR TITLE
Make DatabaseManager more fault tolerant in Cluster

### DIFF
--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,7 +27,7 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "4d449aa198fd5cceca54cb3889114ab5aa1b8e5e",
+        commit = "3227b9e07c9c2317c0e7eab29259204f92433d76",
     )
 
 def graknlabs_grakn_cluster_artifacts():
@@ -37,5 +37,5 @@ def graknlabs_grakn_cluster_artifacts():
         artifact_name = "grakn-cluster-server-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "93cbc149d7b9ce588e52d8132c8a0b2265658a3c",
+        commit = "892073639b024904a413154011fb42d9dae090f3",
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -36,6 +36,6 @@ def graknlabs_common():
 def graknlabs_behaviour():
     git_repository(
         name = "graknlabs_behaviour",
-        remote = "https://github.com/graknlabs/behaviour",
-        commit = "5a3b731b3ef154b5b1bd95b788dc374bd8873746" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        remote = "https://github.com/alexjpwalker/behaviour",
+        commit = "2033a33d17621edce938ad50c7072de14efdd3ba" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -36,6 +36,6 @@ def graknlabs_common():
 def graknlabs_behaviour():
     git_repository(
         name = "graknlabs_behaviour",
-        remote = "https://github.com/alexjpwalker/behaviour",
-        commit = "401b2e52b87a787fab2bc208415af1a822a17b55" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        remote = "https://github.com/graknlabs/behaviour",
+        commit = "9f1cf29952dddaaee96a9ce3b982a8e4d6d45c48" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -37,5 +37,5 @@ def graknlabs_behaviour():
     git_repository(
         name = "graknlabs_behaviour",
         remote = "https://github.com/alexjpwalker/behaviour",
-        commit = "2033a33d17621edce938ad50c7072de14efdd3ba" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        commit = "401b2e52b87a787fab2bc208415af1a822a17b55" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )

--- a/grakn/client.py
+++ b/grakn/client.py
@@ -44,8 +44,8 @@ class GraknClient(ABC):
         return _RPCGraknClient(address)
 
     @staticmethod
-    def cluster(address=DEFAULT_ADDRESS) -> "GraknClient":
-        return _RPCGraknClientCluster(address)
+    def cluster(addresses: List[str]) -> "GraknClient":
+        return _RPCGraknClientCluster(addresses)
 
     @abstractmethod
     def session(self, database: str, session_type: SessionType, options: GraknOptions = None) -> Session:
@@ -112,8 +112,8 @@ class _RPCGraknClient(GraknClient):
 # _RPCGraknClientCluster must live in this package because of circular ref with GraknClient
 class _RPCGraknClientCluster(GraknClient):
 
-    def __init__(self, address: str):
-        self._core_clients: Dict[Address.Server, _RPCGraknClient] = {addr: _RPCGraknClient(addr.client()) for addr in self._discover_cluster([address])}
+    def __init__(self, addresses: List[str]):
+        self._core_clients: Dict[Address.Server, _RPCGraknClient] = {addr: _RPCGraknClient(addr.client()) for addr in self._discover_cluster(addresses)}
         self._grakn_cluster_grpc_stubs = {addr: GraknClusterStub(client.channel()) for (addr, client) in self._core_clients.items()}
         self._databases = _RPCDatabaseManagerCluster({addr: client.databases() for (addr, client) in self._core_clients.items()})
         self._is_open = True

--- a/grakn/rpc/cluster/database_manager.py
+++ b/grakn/rpc/cluster/database_manager.py
@@ -41,7 +41,7 @@ class _RPCDatabaseManagerCluster(DatabaseManager):
 
     def create(self, name: str) -> None:
         for database_manager in self._database_managers.values():
-            if database_manager.contains(name):
+            if not database_manager.contains(name):
                 database_manager.create(name)
 
     def delete(self, name: str) -> None:

--- a/tests/behaviour/background/cluster/environment.py
+++ b/tests/behaviour/background/cluster/environment.py
@@ -22,12 +22,19 @@ from grakn.client import GraknClient
 from tests.behaviour.context import Context
 
 
+IGNORE_TAGS = ["ignore", "ignore-client-python", "ignore-cluster"]
+
+
 def before_all(context: Context):
     environment_base.before_all(context)
     context.client = GraknClient.cluster([GraknClient.DEFAULT_ADDRESS])
 
 
 def before_scenario(context: Context, scenario):
+    for tag in IGNORE_TAGS:
+        if tag in scenario.effective_tags:
+            scenario.skip("tagged with @" + tag)
+            return
     environment_base.before_scenario(context, scenario)
 
 

--- a/tests/behaviour/background/cluster/environment.py
+++ b/tests/behaviour/background/cluster/environment.py
@@ -24,7 +24,7 @@ from tests.behaviour.context import Context
 
 def before_all(context: Context):
     environment_base.before_all(context)
-    context.client = GraknClient.cluster()
+    context.client = GraknClient.cluster([GraknClient.DEFAULT_ADDRESS])
 
 
 def before_scenario(context: Context, scenario):

--- a/tests/behaviour/background/core/environment.py
+++ b/tests/behaviour/background/core/environment.py
@@ -22,12 +22,19 @@ from grakn.client import GraknClient
 from tests.behaviour.context import Context
 
 
+IGNORE_TAGS = ["ignore", "ignore-client-python", "ignore-core"]
+
+
 def before_all(context: Context):
     environment_base.before_all(context)
     context.client = GraknClient.core()
 
 
 def before_scenario(context: Context, scenario):
+    for tag in IGNORE_TAGS:
+        if tag in scenario.effective_tags:
+            scenario.skip("tagged with @" + tag)
+            return
     environment_base.before_scenario(context, scenario)
 
 

--- a/tests/behaviour/background/environment_base.py
+++ b/tests/behaviour/background/environment_base.py
@@ -25,8 +25,6 @@ from tests.behaviour.context import Context, ThingSubtype
 
 import time
 
-IGNORE_TAGS = ["ignore", "ignore-client-python"]
-
 
 def before_all(context: Context):
     context.THREAD_POOL_SIZE = 32
@@ -34,11 +32,6 @@ def before_all(context: Context):
 
 
 def before_scenario(context: Context, scenario):
-    for tag in IGNORE_TAGS:
-        if tag in scenario.effective_tags:
-            scenario.skip("tagged with @" + tag)
-            return
-
     for database in context.client.databases().all():
         context.client.databases().delete(database)
     context.sessions = []

--- a/tests/integration/test_cluster_failover.py
+++ b/tests/integration/test_cluster_failover.py
@@ -32,7 +32,7 @@ from grakn.rpc.cluster.session import _RPCSessionCluster
 class TestClusterFailover(TestCase):
 
     def setUp(self):
-        with GraknClient.cluster("localhost:11729") as client:
+        with GraknClient.cluster(["localhost:11729", "localhost:21729", "localhost:31729"]) as client:
             if "grakn" in client.databases().all():
                 client.databases().delete("grakn")
             client.databases().create("grakn")
@@ -56,7 +56,7 @@ class TestClusterFailover(TestCase):
                 return self.get_primary_replica()
 
     def test_put_entity_type_to_crashed_primary_replica(self):
-        with GraknClient.cluster("localhost:11729") as client:
+        with GraknClient.cluster(["localhost:11729", "localhost:21729", "localhost:31729"]) as client:
             assert client.databases().contains("grakn")
             primary_replica = self.get_primary_replica()
             print("Performing operations against the primary replica " + str(primary_replica))

--- a/tools/behave_rule.bzl
+++ b/tools/behave_rule.bzl
@@ -64,7 +64,7 @@ def _rule_implementation(ctx):
            echo Starting Grakn Server
            mkdir ./grakn_distribution/"$DIRECTORY"/grakn_test
            ./grakn_distribution/"$DIRECTORY"/grakn server --data grakn_test &
-           sleep 8
+           sleep 9
 
            """
     # TODO: If two step files have the same name, we should rename the second one to prevent conflict


### PR DESCRIPTION
## What is the goal of this PR?

We've introduced a couple of fault tolerance improvements into the Grakn Cluster version of DatabaseManager:

- `contains` and `all` will now try to retrieve information from every node, instead of failing if the first node is down
- `create` and `delete` will now be applied to every working node, even if some nodes are down.

For now, this means `create` will no longer throw if the database already exists, and `delete` will no longer throw if the database doesn't exist.

## What are the changes implemented in this PR?

- `contains` and `all` will now try to retrieve information from every node, instead of failing if the first node is down
- `create` and `delete` will now be applied to every working node, even if some nodes are down.
