### PR TITLE
Speed up CI

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -53,6 +53,7 @@ build:
       type: foreground
       command: |
         pyenv global 3.6.10
+        pip3 install -U pip
         pip install -r requirements_dev.txt
         sudo unlink /usr/bin/python3
         sudo ln -s $(which python3) /usr/bin/python3
@@ -66,6 +67,7 @@ build:
       type: foreground
       command: |
         pyenv global 3.6.10
+        pip3 install -U pip
         pip install -r requirements_dev.txt
         sudo unlink /usr/bin/python3
         sudo ln -s $(which python3) /usr/bin/python3
@@ -79,6 +81,7 @@ build:
       type: foreground
       command: |
         pyenv global 3.6.10
+        pip3 install -U pip
         pip install -r requirements_dev.txt
         sudo unlink /usr/bin/python3
         sudo ln -s $(which python3) /usr/bin/python3
@@ -93,6 +96,7 @@ build:
       type: foreground
       command: |
         pyenv global 3.6.10
+        pip3 install -U pip
         pip install -r requirements_dev.txt
         sudo unlink /usr/bin/python3
         sudo ln -s $(which python3) /usr/bin/python3
@@ -109,6 +113,7 @@ build:
       type: foreground
       command: |
         pyenv global 3.6.10
+        pip3 install -U pip
         pip install -r requirements_dev.txt
         sudo unlink /usr/bin/python3
         sudo ln -s $(which python3) /usr/bin/python3
@@ -125,6 +130,7 @@ build:
       type: foreground
       command: |
         pyenv global 3.6.10
+        pip3 install -U pip
         pip install -r requirements_dev.txt
         sudo unlink /usr/bin/python3
         sudo ln -s $(which python3) /usr/bin/python3
@@ -142,6 +148,7 @@ build:
       type: foreground
       command: |
         pyenv global 3.6.10
+        pip3 install -U pip
         sudo unlink /usr/bin/python3
         sudo ln -s $(which python3) /usr/bin/python3
         sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.6.10/lib/python3.6/site-packages/lsb_release.py
@@ -157,6 +164,7 @@ build:
       type: foreground
       command: |
         pyenv global 3.6.10
+        pip3 install -U pip
         sudo unlink /usr/bin/python3
         sudo ln -s $(which python3) /usr/bin/python3
         sudo ln -s /usr/share/pyshared/lsb_release.py /opt/pyenv/versions/3.6.10/lib/python3.6/site-packages/lsb_release.py
@@ -182,6 +190,7 @@ release:
       command: |
         pyenv install -s 3.6.10
         pyenv global 3.6.10 system
+        pip3 install -U pip
         pip install certifi
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
@@ -195,6 +204,7 @@ release:
       command: |
         pyenv install -s 3.6.10
         pyenv global 3.6.10 system
+        pip3 install -U pip
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -44,7 +44,7 @@ kt_register_toolchains()
 # Load //builder/python
 load("@graknlabs_dependencies//builder/python:deps.bzl", python_deps = "deps")
 python_deps()
-load("@rules_python//python:pip.bzl", "pip_repositories", "pip3_import")
+load("@rules_python//python:pip.bzl", "pip_repositories", "pip_import")
 pip_repositories()
 
 # Load //builder/grpc
@@ -58,8 +58,6 @@ com_github_grpc_grpc_deps()
 load("@graknlabs_dependencies//tool/common:deps.bzl", "graknlabs_dependencies_ci_pip",
     graknlabs_dependencies_tool_maven_artifacts = "maven_artifacts")
 graknlabs_dependencies_ci_pip()
-load("@graknlabs_dependencies_ci_pip//:requirements.bzl", graknlabs_dependencies_pip_install = "pip_install")
-graknlabs_dependencies_pip_install()
 
 # Load //tool/checkstyle
 load("@graknlabs_dependencies//tool/checkstyle:deps.bzl", checkstyle_deps = "deps")
@@ -81,8 +79,6 @@ rules_pkg_dependencies()
 # Load //pip
 load("@graknlabs_bazel_distribution//pip:deps.bzl", pip_deps = "deps")
 pip_deps()
-load("@graknlabs_bazel_distribution_pip//:requirements.bzl", graknlabs_bazel_distribution_pip_install = "pip_install")
-graknlabs_bazel_distribution_pip_install()
 
 # Load //github
 load("@graknlabs_bazel_distribution//github:deps.bzl", github_deps = "deps")
@@ -105,13 +101,11 @@ graknlabs_grakn_cluster_artifacts()
 # Load @graknlabs_client_python #
 #################################
 
-pip3_import(
+load("@rules_python//python:pip.bzl", "pip_install")
+pip_install(
     name = "graknlabs_client_python_pip",
     requirements = "//:requirements_dev.txt",
 )
-load("@graknlabs_client_python_pip//:requirements.bzl",
-graknlabs_client_python_pip_install = "pip_install")
-graknlabs_client_python_pip_install()
 
 ############################
 # Load @maven dependencies #

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -23,7 +23,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "1fe947a6a7f78d6b0dbe14481cdd0d6929988e5e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "87e44466b11b7e6b24bcfd847430ffd904af9232",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_common():


### PR DESCRIPTION
## What is the goal of this PR?

Cut the time spent on CI jobs by upgrading to latest `@rules_python` and `pip`

## What are the changes implemented in this PR?

Use latest `pip` (both in standalone tests and in Bazel targets) to ensure that `grpcio` native library is not rebuilt from scratch every time but just fetched from PyPI.