### PR TITLE
Bind Cluster sessions to single server nodes, and add naive load balancing

### DIFF
--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,7 +27,7 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "3227b9e07c9c2317c0e7eab29259204f92433d76",
+        commit = "4d449aa198fd5cceca54cb3889114ab5aa1b8e5e",
     )
 
 def graknlabs_grakn_cluster_artifacts():
@@ -37,5 +37,5 @@ def graknlabs_grakn_cluster_artifacts():
         artifact_name = "grakn-cluster-server-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "93cbc149d7b9ce588e52d8132c8a0b2265658a3c",
+        commit = "55bb7a5bb99fecf6990b0e8ed3220b264f8de452",
     )

--- a/grakn/client.py
+++ b/grakn/client.py
@@ -171,8 +171,8 @@ class _ClientClusterRPC(GraknClient):
                     members = set([ServerAddress.parse(srv) for srv in res.servers])
                     print("Discovered %s" % [str(member) for member in members])
                     return members
-            except RpcError:
-                print("Cluster discovery to %s failed." % address)
+            except RpcError as e:
+                print("Cluster discovery to %s failed. %s" % (address, str(e)))
         raise GraknClientException("Unable to connect to Grakn Cluster. Attempted connecting to the cluster members, but none are available: %s" % str(addresses))
 
 

--- a/grakn/rpc/cluster/failsafe_task.py
+++ b/grakn/rpc/cluster/failsafe_task.py
@@ -1,0 +1,123 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import time
+from abc import ABC, abstractmethod
+
+import grakn_protocol.protobuf.cluster.database_pb2 as database_proto
+from grpc import RpcError, StatusCode
+
+from grakn.common.exception import GraknClientException
+from grakn.rpc.cluster.replica_info import ReplicaInfo
+
+
+class FailsafeTask(ABC):
+
+    PRIMARY_REPLICA_TASK_MAX_RETRIES = 10
+    FETCH_REPLICAS_MAX_RETRIES = 10
+    WAIT_FOR_PRIMARY_REPLICA_SELECTION_SECONDS: float = 2
+
+    def __init__(self, client, database: str):
+        self.client = client
+        self.database = database
+
+    @abstractmethod
+    def run(self, replica: ReplicaInfo.Replica):
+        pass
+
+    def rerun(self, replica: ReplicaInfo.Replica):
+        return self.run(replica)
+
+    def run_primary_replica(self):
+        if self.database not in self.client.replica_info_map() or not self.client.replica_info_map()[self.database].primary_replica():
+            self._seek_primary_replica()
+        replica = self.client.replica_info_map()[self.database].primary_replica()
+        retries = 0
+        while True:
+            try:
+                return self.run(replica) if retries == 0 else self.rerun(replica)
+            except GraknClientException as e:
+                # TODO: propagate exception from the server in a less brittle way
+                if "[RPL01]" in str(e):  # The contacted replica reported that it was not the primary replica
+                    print("Unable to open a session or transaction, retrying in 2s... %s" % str(e))
+                    time.sleep(self.WAIT_FOR_PRIMARY_REPLICA_SELECTION_SECONDS)
+                    replica = self._seek_primary_replica()
+                else:
+                    raise e
+                # TODO: introduce a special type that extends RpcError and Call
+            except RpcError as e:
+                # TODO: this logic should be extracted into GraknClientException
+                # TODO: error message should be checked in a less brittle way
+                if e.code() == StatusCode.UNAVAILABLE or "[INT07]" in str(e) or "Received RST_STREAM" in str(e):
+                    print("Unable to open a session or transaction, retrying in 2s... %s" % str(e))
+                    time.sleep(self.WAIT_FOR_PRIMARY_REPLICA_SELECTION_SECONDS)
+                    replica = self._seek_primary_replica()
+                else:
+                    raise e
+            retries += 1
+            if retries > self.PRIMARY_REPLICA_TASK_MAX_RETRIES:
+                raise self._cluster_not_available_exception()
+
+    def run_any_replica(self):
+        if self.database in self.client.replica_info_map():
+            replica_info = self.client.replica_info_map()[self.database]
+        else:
+            replica_info = self._fetch_database_replicas()
+
+        replicas = [replica_info.preferred_secondary_replica()] + [replica for replica in replica_info.replicas() if not replica.is_preferred_secondary()]
+        retries = 0
+        for replica in replicas:
+            try:
+                return self.run(replica) if retries == 0 else self.rerun(replica)
+            except RpcError as e:
+                if e.code() == StatusCode.UNAVAILABLE or "[INT07]" in str(e) or "Received RST_STREAM" in str(e):
+                    print("Unable to open a session or transaction to %s. Attempting next replica. %s" % (str(replica.replica_id()), str(e)))
+                else:
+                    raise e
+            retries += 1
+        raise self._cluster_not_available_exception()
+
+    def _seek_primary_replica(self) -> ReplicaInfo.Replica:
+        retries = 0
+        while retries < self.FETCH_REPLICAS_MAX_RETRIES:
+            replica_info = self._fetch_database_replicas()
+            if replica_info.primary_replica():
+                return replica_info.primary_replica()
+            else:
+                time.sleep(self.WAIT_FOR_PRIMARY_REPLICA_SELECTION_SECONDS)
+                retries += 1
+        raise self._cluster_not_available_exception()
+
+    def _fetch_database_replicas(self) -> ReplicaInfo:
+        for server_address in self.client.cluster_members():
+            try:
+                print("Fetching replica info from %s" % server_address)
+                db_replicas_req = database_proto.Database.Replicas.Req()
+                db_replicas_req.database = self.database
+                res = self.client.grakn_cluster_grpc_stub(server_address).database_replicas(db_replicas_req)
+                replica_info = ReplicaInfo.of_proto(res)
+                print("Requested database discovery from peer %s, and got response: %s" % (str(server_address), str([str(replica) for replica in replica_info.replicas()])))
+                self.client.replica_info_map()[self.database] = replica_info
+                return replica_info
+            except RpcError as e:
+                print("Unable to perform database discovery to %s. Attempting next address. %s" % (str(server_address), str(e)))
+        raise self._cluster_not_available_exception()
+
+    def _cluster_not_available_exception(self) -> GraknClientException:
+        addresses = str([str(addr) for addr in self.client.cluster_members()])
+        return GraknClientException("Unable to connect to Grakn Cluster. Attempted connecting to the cluster members, but none are available: '%s'" % addresses)

--- a/grakn/rpc/cluster/session.py
+++ b/grakn/rpc/cluster/session.py
@@ -16,54 +16,46 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-import time
-from threading import Lock
-from typing import Dict
 
-import grakn_protocol.protobuf.cluster.database_pb2 as database_proto
-from grpc import RpcError, StatusCode
-
-from grakn.common.exception import GraknClientException
 from grakn.options import GraknClusterOptions, GraknOptions
+from grakn.rpc.cluster.failsafe_task import FailsafeTask
 from grakn.rpc.cluster.replica_info import ReplicaInfo
 from grakn.rpc.cluster.server_address import ServerAddress
-from grakn.rpc.session import Session, SessionType, _SessionRPC
+from grakn.rpc.session import Session, SessionType
 from grakn.rpc.transaction import TransactionType, Transaction
 
 
-class _SessionClusterRPC(Session):
-    MAX_RETRY_PER_REPLICA = 10
-    WAIT_FOR_PRIMARY_REPLICA_SELECTION_SECONDS: float = 2
-    WAIT_AFTER_NETWORK_FAILURE_SECONDS: float = 1
+class SessionClusterRPC(Session):
 
-    def __init__(self, cluster_client, database: str, session_type: SessionType, options: GraknClusterOptions):
-        self._lock = Lock()
-        self._cluster_client = cluster_client
-        self._db_name = database
-        self._session_type = session_type
-        self._options = options
-        self._database = self._discover_database()
-        self._core_sessions: Dict[ReplicaInfo.Replica.Id, _SessionRPC] = {}
-        self._is_open = True
+    def __init__(self, cluster_client, server_address: ServerAddress, database: str, session_type: SessionType, options: GraknClusterOptions):
+        self.cluster_client = cluster_client
+        self.core_client = cluster_client.core_client(server_address)
+        self._database = database
+        print("Opening a session to %s" % server_address)
+        self.core_session = self.core_client.session(database, session_type, options)
 
     def transaction(self, transaction_type: TransactionType, options: GraknClusterOptions = None) -> Transaction:
         if not options:
             options = GraknOptions.cluster()
-        return self._transaction_secondary_replica(transaction_type, options) if options.read_any_replica else self._transaction_primary_replica(transaction_type, options)
+        return self._transaction_any_replica(transaction_type, options) if options.read_any_replica else self._transaction_primary_replica(transaction_type, options)
+
+    def _transaction_primary_replica(self, transaction_type: TransactionType, options: GraknClusterOptions) -> Transaction:
+        return TransactionFailsafeTask(self, transaction_type, options).run_primary_replica()
+
+    def _transaction_any_replica(self, transaction_type: TransactionType, options: GraknClusterOptions) -> Transaction:
+        return TransactionFailsafeTask(self, transaction_type, options).run_any_replica()
 
     def session_type(self) -> SessionType:
-        return self._session_type
+        return self.core_session.session_type()
 
     def is_open(self) -> bool:
-        return self._is_open
+        return self.core_session.is_open()
 
     def close(self) -> None:
-        for core_session in self._core_sessions.values():
-            core_session.close()
-        self._is_open = False
+        self.core_session.close()
 
     def database(self) -> str:
-        return self._db_name
+        return self._database
 
     def __enter__(self):
         return self
@@ -71,82 +63,21 @@ class _SessionClusterRPC(Session):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
-    def _transaction_primary_replica(self, transaction_type: TransactionType, options: GraknOptions) -> Transaction:
-        if not self._database.primary_replica():
-            self._fetch_latest_replica_info(max_retries=self.MAX_RETRY_PER_REPLICA)
-        while True:
-            try:
-                return self._try_open_transaction_in_replica(self._database.primary_replica(), transaction_type, options)
-            except GraknClientException as e:
-                # TODO: propagate exception from the server in a less brittle way
-                if "[RPL01]" in str(e):  # The contacted replica reported that it was not the primary replica
-                    print("Unable to open a session or transaction: %s" % str(e))
-                    self._fetch_latest_replica_info(max_retries=self.MAX_RETRY_PER_REPLICA)
-                else:
-                    raise e
-                # TODO: introduce a special type that extends RpcError and Call
-            except RpcError as e:
-                # TODO: this logic should be extracted into GraknClientException
-                # TODO: error message should be checked in a less brittle way
-                if e.code() == StatusCode.UNAVAILABLE or "[INT07]" in str(e):
-                    print("Unable to open a session or transaction to %s. Seeking new primary replica in 1 second. %s" % (str(self._database.primary_replica().replica_id()), str(e)))
-                    # If the replica is down, it may take some time for a primary to be re-elected, so we wait briefly.
-                    time.sleep(self.WAIT_FOR_PRIMARY_REPLICA_SELECTION_SECONDS)
-                    self._fetch_latest_replica_info(max_retries=self.MAX_RETRY_PER_REPLICA)
-                else:
-                    raise e
 
-    def _transaction_secondary_replica(self, transaction_type: TransactionType, options: GraknClusterOptions) -> Transaction:
-        for replica in self._database.replicas():
-            try:
-                return self._try_open_transaction_in_replica(replica, transaction_type, options)
-            except RpcError as e:
-                if e.code() == StatusCode.UNAVAILABLE or "[INT07]" in str(e):
-                    print("Unable to open a session or transaction to %s. Attempting next replica. %s" % (str(replica.replica_id()), str(e)))
-                else:
-                    raise e
-        raise self._cluster_not_available_exception()
+class TransactionFailsafeTask(FailsafeTask):
 
-    def _core_session(self, replica: ReplicaInfo.Replica) -> _SessionRPC:
-        replica_id = replica.replica_id()
-        with self._lock:
-            if replica_id not in self._core_sessions:
-                print("Opening a session to '%s'" % replica_id)
-                self._core_sessions[replica_id] = self._cluster_client.core_client(replica_id.address()).session(replica_id.database(), self._session_type, self._options)
-            return self._core_sessions[replica_id]
+    def __init__(self, cluster_session: SessionClusterRPC, transaction_type: TransactionType, options: GraknClusterOptions):
+        super().__init__(cluster_session.cluster_client, cluster_session.database())
+        self.cluster_session = cluster_session
+        self.transaction_type = transaction_type
+        self.options = options
 
-    def _try_open_transaction_in_replica(self, replica: ReplicaInfo.Replica, transaction_type: TransactionType, options: GraknOptions) -> Transaction:
-        selected_session = self._core_session(replica)
-        print("Opening a transaction to replica '%s'" % replica.replica_id())
-        return selected_session.transaction(transaction_type, options)
+    def run(self, replica: ReplicaInfo.Replica):
+        return self.cluster_session.core_session.transaction(self.transaction_type, self.options)
 
-    def _fetch_latest_replica_info(self, max_retries) -> ReplicaInfo.Replica:
-        retries = 0
-        while retries < max_retries:
-            self._database = self._discover_database()
-            if self._database.primary_replica():
-                return self._database.primary_replica()
-            else:
-                time.sleep(self.WAIT_FOR_PRIMARY_REPLICA_SELECTION_SECONDS)
-                retries += 1
-        raise self._cluster_not_available_exception()
-
-    def _discover_database(self, server_address: ServerAddress = None) -> ReplicaInfo:
-        if server_address:
-            db_discover_req = database_proto.Database.Discover.Req()
-            db_discover_req.database = self._db_name
-            res = self._cluster_client.grakn_cluster_grpc_stub(server_address).database_discover(db_discover_req)
-            db = ReplicaInfo.of_proto(res)
-            print("Requested database discovery from peer %s, and got response: %s" % (str(server_address), str([str(replica) for replica in db.replicas()])))
-            return db
-        else:
-            for server_addr in self._cluster_client.cluster_members():
-                try:
-                    return self._discover_database(server_addr)
-                except RpcError as e:
-                    print("Unable to perform database discovery to %s. Attempting next address. %s" % (str(server_addr), str(e)))
-            raise self._cluster_not_available_exception()
-
-    def _cluster_not_available_exception(self) -> GraknClientException:
-        addresses = str([str(addr) for addr in self._cluster_client.cluster_members()])
-        return GraknClientException("Unable to connect to Grakn Cluster. Attempted connecting to the cluster members, but none are available: '%s'" % addresses)
+    def rerun(self, replica: ReplicaInfo.Replica):
+        if self.cluster_session.core_session:
+            self.cluster_session.core_session.close()
+        self.cluster_session.core_client = self.cluster_session.cluster_client.core_client(replica.address())
+        self.cluster_session.core_session = self.cluster_session.core_client.session(self.database, self.cluster_session.session_type(), self.options)
+        return self.cluster_session.core_session.transaction(self.transaction_type, self.options)

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,6 @@
 
 ## Dependencies
 
-grakn-protocol==2.0.0a8
+grakn-protocol==0.0.0-cb7063afe613b51635b07df1975202ceda9de313
 grpcio==1.35.0
 protobuf==3.14.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -25,7 +25,7 @@
 
 ## Dependencies
 
-grakn-protocol==0.0.0-e2a1b72cf15eb4231de5b979c0d683a5b49a169e
+grakn-protocol==0.0.0-cb7063afe613b51635b07df1975202ceda9de313
 grpcio==1.35.0
 protobuf==3.14.0
 

--- a/tests/integration/test_cluster_failover.py
+++ b/tests/integration/test_cluster_failover.py
@@ -41,10 +41,10 @@ class TestClusterFailover(TestCase):
         channel = grpc.insecure_channel("localhost:11729")
         cluster_grpc_stub = GraknClusterStub(channel)
         while True:
-            db_discover_req = database_proto.Database.Discover.Req()
-            db_discover_req.database = "grakn"
+            db_replicas_req = database_proto.Database.Replicas.Req()
+            db_replicas_req.database = "grakn"
             print("Discovering replicas for database 'grakn'...")
-            res = cluster_grpc_stub.database_discover(db_discover_req)
+            res = cluster_grpc_stub.database_replicas(db_replicas_req)
             dbs = ReplicaInfo.of_proto(res)
             print("Discovered " + str([str(replica) for replica in dbs.replicas()]))
             primary_replica = next(iter([replica for replica in dbs.replicas() if replica.is_primary()]), None)


### PR DESCRIPTION
## What is the goal of this PR?

Previously, each Cluster session would lazily create Core sessions on-demand as Transactions were opened. This delegated too much responsibility to the Transaction. Now, each Cluster session is bound to a single server node, which may be a primary or a secondary node depending on the Options passed to the Session.

We also select secondary nodes in a fairer, more balanced way; the server indicates which node is its first preference for secondary sessions, and the client tries to obey the server's decision, with fallback to backup nodes only in the event of a failure.

## What are the changes implemented in this PR?

- On creating a Cluster session, a Core session is immediately created to a server node of the appropriate type
- Node selection is based on the `read_any_replica` Option passed to the Session
- When `read_any_replica` is `true`, the client will first select nodes that the server has indicated are "preferred secondary", with fallback to backup nodes only in the event of a failure