### PR TITLE
Raise StopIteration when iterating over an already-completed Stream

### DIFF
--- a/grakn/rpc/stream.py
+++ b/grakn/rpc/stream.py
@@ -39,6 +39,8 @@ class Stream:
         return self
 
     def __next__(self):
+        if self._done:
+            raise StopIteration()
         if self._current_iterator is not None:
             try:
                 return next(self._current_iterator)
@@ -54,6 +56,7 @@ class Stream:
             self._transaction._request_iterator.put(continue_req)
             return next(self)
         elif res_case == Stream._DONE:
+            self._done = True
             raise StopIteration()
         elif res_case is None:
             raise GraknClientException("The required field 'res' of type 'transaction_proto.Transaction.Res' was not set.")

--- a/grakn/rpc/stream.py
+++ b/grakn/rpc/stream.py
@@ -34,6 +34,7 @@ class Stream:
         self._request_id = request_id
         self._transform_response = transform_response
         self._current_iterator = None
+        self._done = False
 
     def __iter__(self):
         return self


### PR DESCRIPTION
## What is the goal of this PR?

Previously, iterating over an already-completed Stream would stall. Now, we instead raise a `StopIteration` error.

## What are the changes implemented in this PR?

Raise StopIteration when iterating over an already-completed Stream