### PR TITLE
Add option to enable inference tracing

### DIFF
--- a/grakn/grakn_proto_builder.py
+++ b/grakn/grakn_proto_builder.py
@@ -27,8 +27,8 @@ def options(opts: Union[GraknOptions, GraknClusterOptions]):
     proto_options = options_proto.Options()
     if opts.infer is not None:
         proto_options.infer = opts.infer
-    if opts.infer_log is not None:
-        proto_options.infer_log = opts.infer_log
+    if opts.trace_inference is not None:
+        proto_options.trace_inference = opts.trace_inference
     if opts.explain is not None:
         proto_options.explain = opts.explain
     if opts.batch_size is not None:

--- a/grakn/grakn_proto_builder.py
+++ b/grakn/grakn_proto_builder.py
@@ -27,6 +27,8 @@ def options(opts: Union[GraknOptions, GraknClusterOptions]):
     proto_options = options_proto.Options()
     if opts.infer is not None:
         proto_options.infer = opts.infer
+    if opts.infer_log is not None:
+        proto_options.infer_log = opts.infer_log
     if opts.explain is not None:
         proto_options.explain = opts.explain
     if opts.batch_size is not None:

--- a/grakn/options.py
+++ b/grakn/options.py
@@ -24,6 +24,7 @@ class GraknOptions(ABC):
 
     def __init__(self):
         self.infer: Optional[bool] = None
+        self.infer_log: Optional[bool] = None
         self.explain: Optional[bool] = None
         self.batch_size: Optional[int] = None
 

--- a/grakn/options.py
+++ b/grakn/options.py
@@ -24,7 +24,7 @@ class GraknOptions(ABC):
 
     def __init__(self):
         self.infer: Optional[bool] = None
-        self.infer_log: Optional[bool] = None
+        self.trace_inference: Optional[bool] = None
         self.explain: Optional[bool] = None
         self.batch_size: Optional[int] = None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,6 @@
 ## Dependencies
 
 # IMPORTANT: Any changes to these dependencies should be copied to requirements_dev.txt.
-grakn-protocol==0.0.0-d46172adcf1fcb40d82d7cfeab42d3e2a95485b8
+grakn-protocol==0.0.0-7c78ea569d33324214c9867b4952d6d4c16c45df
 grpcio==1.35.0
 protobuf==3.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,6 @@
 ## Dependencies
 
 # IMPORTANT: Any changes to these dependencies should be copied to requirements_dev.txt.
-grakn-protocol==0.0.0-b63c9b9b5027d354107dc0c22f61d5f5aaa224ed
+grakn-protocol==0.0.0-d46172adcf1fcb40d82d7cfeab42d3e2a95485b8
 grpcio==1.35.0
 protobuf==3.14.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -28,7 +28,7 @@
 
 ## Dependencies
 
-grakn-protocol==0.0.0-d46172adcf1fcb40d82d7cfeab42d3e2a95485b8
+grakn-protocol==0.0.0-7c78ea569d33324214c9867b4952d6d4c16c45df
 grpcio==1.35.0
 protobuf==3.14.0
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -28,7 +28,7 @@
 
 ## Dependencies
 
-grakn-protocol==0.0.0-b63c9b9b5027d354107dc0c22f61d5f5aaa224ed
+grakn-protocol==0.0.0-d46172adcf1fcb40d82d7cfeab42d3e2a95485b8
 grpcio==1.35.0
 protobuf==3.14.0
 


### PR DESCRIPTION
## What is the goal of this PR?

We introduce a new option to allow tracing the internals of Grakn's reasoner.

## What are the changes implemented in this PR?

- Adds a new option, the flag `traceInference`.

Requires https://github.com/graknlabs/protocol/pull/122