### PR TITLE
When closing a client, also close all its sessions

### DIFF
--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,7 +27,7 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "5f96fb705f8f256e8cb1b918fe85893056c827d2",
+        commit = "0c2a8f84e83ea4bb84a1d59d9f50fd0c9afffd9e",
     )
 
 def graknlabs_grakn_cluster_artifacts():

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,7 +27,7 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "0c2a8f84e83ea4bb84a1d59d9f50fd0c9afffd9e",
+        commit = "390b798bbc8e0511ddf456eab43378e30cc0e9a1",
     )
 
 def graknlabs_grakn_cluster_artifacts():

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,7 +27,7 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "390b798bbc8e0511ddf456eab43378e30cc0e9a1",
+        commit = "c04b5f105914c690cbd54e6bdc6a4eb9dda2b3e7",
     )
 
 def graknlabs_grakn_cluster_artifacts():
@@ -37,5 +37,5 @@ def graknlabs_grakn_cluster_artifacts():
         artifact_name = "grakn-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "cc3382fe6be239973f1e7d8437a71683e3dff809",
+        commit = "a5cf161f63b33010009c63e2b955d2fa81e4e736",
     )

--- a/grakn/rpc/transaction.py
+++ b/grakn/rpc/transaction.py
@@ -45,7 +45,7 @@ class TransactionType(enum.Enum):
 
 class Transaction:
 
-    def __init__(self, address: str, session_id: str, transaction_type: TransactionType, options: GraknOptions = None):
+    def __init__(self, address: str, session_id: bytes, transaction_type: TransactionType, options: GraknOptions = None):
         if not options:
             options = GraknOptions.core()
         self._transaction_type = transaction_type

--- a/tools/behave_rule.bzl
+++ b/tools/behave_rule.bzl
@@ -110,7 +110,7 @@ def _rule_implementation(ctx):
     cmd += " && rm -rf " + steps_out_dir
     cmd += " && mkdir " + steps_out_dir + " && "
     cmd += " && ".join(["cp %s %s" % (step_file.path, steps_out_dir) for step_file in ctx.files.steps])
-    cmd += " && behave %s -D port=$PORT && export RESULT=0 || export RESULT=1" % feats_dir
+    cmd += " && behave %s --no-capture -D port=$PORT && export RESULT=0 || export RESULT=1" % feats_dir
     cmd += """
            echo Tests concluded with exit value $RESULT
            echo Stopping server.


### PR DESCRIPTION
## What is the goal of this PR?

The `close` method of `GraknClient` now automatically closes all `Session` objects that were opened from that client.

## What are the changes implemented in this PR?

The `close` method of `GraknClient` now automatically closes all `Session` objects that were opened from that client.