### PR TITLE
Store more complete cluster address information

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -126,6 +126,7 @@ build:
         bazel test //tests/behaviour/graql/language/undefine:checkstyle --test_output=errors
         bazel test //tests/behaviour/graql/language/undefine:test-core --test_output=errors
     test-cluster-failover:
+      machine: 4-core-8-gb
       image: graknlabs-ubuntu-20.04
       type: foreground
       command: |

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -139,7 +139,7 @@ build:
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-        bazel test //tests:test_cluster_failover --test_output=errors
+        bazel test //tests:test_cluster_failover --test_output=streamed
     deploy-pip-snapshot:
       image: graknlabs-ubuntu-20.04
       dependencies: [build, test-behaviour-connection, test-behaviour-concept, test-behaviour-match, test-behaviour-writable, test-behaviour-definable, test-cluster-failover]

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -37,5 +37,5 @@ def graknlabs_grakn_cluster_artifacts():
         artifact_name = "grakn-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "a5cf161f63b33010009c63e2b955d2fa81e4e736",
+        commit = "ae8aeb4919887d96aca24aa9029e9827b6437b35",
     )

--- a/grakn/rpc/cluster/server_address.py
+++ b/grakn/rpc/cluster/server_address.py
@@ -17,43 +17,59 @@
 # under the License.
 #
 
+from grakn.common.exception import GraknClientException
+
 
 class ServerAddress:
 
-    def __init__(self, host: str, client_port: int, server_port: int):
-        self._host = host
+    def __init__(self, client_host: str, client_port: int, server_host: str, server_port: int):
+        self._client_host = client_host
         self._client_port = client_port
+        self._server_host = server_host
         self._server_port = server_port
 
-    def host(self) -> str:
-        return self._host
+    def client_host(self) -> str:
+        return self._client_host
 
     def client_port(self) -> int:
         return self._client_port
+
+    def server_host(self) -> str:
+        return self._server_host
 
     def server_port(self) -> int:
         return self._server_port
 
     def server(self) -> str:
-        return "%s:%d" % (self._host, self._server_port)
+        return "%s:%d" % (self._server_host, self._server_port)
 
     def client(self) -> str:
-        return "%s:%d" % (self._host, self._client_port)
+        return "%s:%d" % (self._client_host, self._client_port)
 
     def __eq__(self, other):
         if other is self:
             return True
         if not other or type(self) != type(other):
             return False
-        return self._client_port == other.client_port() and self._server_port == other.server_port() and self._host == other.host()
+        return self._client_host == other.client_host() and self._client_port == other.client_port() and self._server_host == other.server_host() and self._server_port == other.server_port()
 
     def __hash__(self):
-        return hash((self._host, self._client_port, self._server_port))
+        return hash((self._client_host, self._client_port, self._server_host, self._server_port))
 
     def __str__(self):
-        return "%s:%d:%d" % (self._host, self._client_port, self._server_port)
+        return "%s,%s" % (self.client(), self.server())
 
     @staticmethod
     def parse(address: str) -> "ServerAddress":
-        s = address.split(":")
-        return ServerAddress(host=s[0], client_port=int(s[1]), server_port=int(s[2]))
+        s = address.split(",")
+        if len(s) == 1:
+            s1 = address.split(":")
+            return ServerAddress(client_host=s1[0], client_port=int(s1[1]), server_host=s1[0], server_port=int(s1[1]))
+        elif len(s) == 2:
+            client_url = s[0].split(":")
+            server_url = s[1].split(":")
+            if len(client_url) != 2 or len(server_url) != 2:
+                raise GraknClientException("Failed to parse server address: " + address)
+            return ServerAddress(client_host=client_url[0], client_port=int(client_url[1]), server_host=server_url[0], server_port=int(server_url[1]))
+        else:
+            raise GraknClientException("Failed to parse server address: " + address)

--- a/tests/integration/test_cluster_failover.py
+++ b/tests/integration/test_cluster_failover.py
@@ -65,7 +65,7 @@ class TestClusterFailover(TestCase):
             lsof = subprocess.check_output(["lsof", "-i", ":%d" % port])
             primary_replica_server_pid = [conn.split()[1] for conn in lsof.decode("utf-8").split("\n") if "LISTEN" in conn][0]
             print("Primary replica is hosted by server with PID %s" % primary_replica_server_pid)
-            subprocess.check_call(["kill", primary_replica_server_pid])
+            subprocess.check_call(["kill", "-9", primary_replica_server_pid])
             print("Primary replica stopped successfully.")
             with client.session("grakn", SessionType.SCHEMA) as session, session.transaction(TransactionType.READ) as tx:
                 person = tx.concepts().get_entity_type("person")

--- a/tests/integration/test_cluster_failover.py
+++ b/tests/integration/test_cluster_failover.py
@@ -60,18 +60,25 @@ class TestClusterFailover(TestCase):
                 person = tx.concepts().get_entity_type("person")
                 print("Retrieved entity type with label '%s' from primary replica." % person.get_label())
                 assert person.get_label() == "person"
-            print("Stopping primary replica...")
-            port = primary_replica.replica_id().address().server_port()
-            lsof = subprocess.check_output(["lsof", "-i", ":%d" % port])
-            primary_replica_server_pid = [conn.split()[1] for conn in lsof.decode("utf-8").split("\n") if "LISTEN" in conn][0]
-            print("Primary replica is hosted by server with PID %s" % primary_replica_server_pid)
-            subprocess.check_call(["kill", "-9", primary_replica_server_pid])
-            print("Primary replica stopped successfully.")
-            with client.session("grakn", SessionType.SCHEMA) as session, session.transaction(TransactionType.READ) as tx:
-                person = tx.concepts().get_entity_type("person")
-                print("Retrieved entity type with label '%s' from new primary replica." % person.get_label())
-                assert person.get_label() == "person"
-
+            iteration = 0
+            while iteration < 10:
+                iteration += 1
+                primary_replica = self.get_primary_replica(client.databases())
+                print("Stopping primary replica (test %d/10)..." % iteration)
+                port = primary_replica.replica_id().address().server_port()
+                lsof = subprocess.check_output(["lsof", "-i", ":%d" % port])
+                primary_replica_server_pid = [conn.split()[1] for conn in lsof.decode("utf-8").split("\n") if "LISTEN" in conn][0]
+                print("Primary replica is hosted by server with PID %s" % primary_replica_server_pid)
+                subprocess.check_call(["kill", "-9", primary_replica_server_pid])
+                print("Primary replica stopped successfully.")
+                sleep(1)
+                with client.session("grakn", SessionType.SCHEMA) as session, session.transaction(TransactionType.READ) as tx:
+                    person = tx.concepts().get_entity_type("person")
+                    print("Retrieved entity type with label '%s' from new primary replica." % person.get_label())
+                    assert person.get_label() == "person"
+                idx = str(primary_replica.address().client_port())[0]
+                subprocess.Popen(["./%s/grakn" % idx, "server", "--data", "data", "--address", "127.0.0.1:%s1729:%s1730" % (idx, idx), "--peer", "127.0.0.1:11729:11730", "--peer", "127.0.0.1:21729:21730", "--peer", "127.0.0.1:31729:31730"])
+                sleep(10)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tools/cluster_test_rule.bzl
+++ b/tools/cluster_test_rule.bzl
@@ -54,10 +54,10 @@ def _rule_implementation(ctx):
            echo Successfully unarchived Grakn distribution. Creating 3 copies.
            cp -r grakn_distribution/$GRAKN/ 1 && cp -r grakn_distribution/$GRAKN/ 2 && cp -r grakn_distribution/$GRAKN/ 3
            echo Starting 3 Grakn servers.
-           ./1/grakn server --data data --address=127.0.0.1:11729:11730 --peers=127.0.0.1:11729:11730,127.0.0.1:21729:21730,127.0.0.1:31729:31730 &
-           ./2/grakn server --data data --address=127.0.0.1:21729:21730 --peers=127.0.0.1:11729:11730,127.0.0.1:21729:21730,127.0.0.1:31729:31730 &
-           ./3/grakn server --data data --address=127.0.0.1:31729:31730 --peers=127.0.0.1:11729:11730,127.0.0.1:21729:21730,127.0.0.1:31729:31730 &
-           sleep 20
+           ./1/grakn server --data data --address 127.0.0.1:11729:11730 --peer 127.0.0.1:11729:11730 --peer 127.0.0.1:21729:21730 --peer 127.0.0.1:31729:31730 &
+           ./2/grakn server --data data --address 127.0.0.1:21729:21730 --peer 127.0.0.1:11729:11730 --peer 127.0.0.1:21729:21730 --peer 127.0.0.1:31729:31730 &
+           ./3/grakn server --data data --address 127.0.0.1:31729:31730 --peer 127.0.0.1:11729:11730 --peer 127.0.0.1:21729:21730 --peer 127.0.0.1:31729:31730 &
+           sleep 10
 
            """
 


### PR DESCRIPTION
## What is the goal of this PR?

We now store both "client address" and "server address". The former is the address that the client will use when connecting to the cluster, whereas the latter is the address that a cluster member use to talk to its peers.

## What are the changes implemented in this PR?

1. Update the `ServerAddress` class to include client host + port, and server host + port