### PR TITLE
Add parallel option 

### DIFF
--- a/grakn/grakn_proto_builder.py
+++ b/grakn/grakn_proto_builder.py
@@ -31,6 +31,8 @@ def options(opts: Union[GraknOptions, GraknClusterOptions]):
         proto_options.trace_inference = opts.trace_inference
     if opts.explain is not None:
         proto_options.explain = opts.explain
+    if opts.parallel is not None:
+        proto_options.parallel = opts.parallel
     if opts.batch_size is not None:
         proto_options.batch_size = opts.batch_size
     if opts.is_cluster() and opts.read_any_replica is not None:

--- a/grakn/options.py
+++ b/grakn/options.py
@@ -26,6 +26,7 @@ class GraknOptions(ABC):
         self.infer: Optional[bool] = None
         self.trace_inference: Optional[bool] = None
         self.explain: Optional[bool] = None
+        self.parallel: Optional[bool] = None
         self.batch_size: Optional[int] = None
 
     @staticmethod

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,6 @@
 ## Dependencies
 
 # IMPORTANT: Any changes to these dependencies should be copied to requirements_dev.txt.
-grakn-protocol==2.0.0a10
+grakn-protocol==0.0.0-195cedd57551936d42c28b258c820263fcc1b563
 grpcio==1.35.0
 protobuf==3.14.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -28,7 +28,7 @@
 
 ## Dependencies
 
-grakn-protocol==2.0.0a10
+grakn-protocol==0.0.0-195cedd57551936d42c28b258c820263fcc1b563
 grpcio==1.35.0
 protobuf==3.14.0
 


### PR DESCRIPTION
## What is the goal of this PR?

We allow client-java to set the parallelism of the server explicitly (useful in conjunction with traceInference, which is effective only with no parallelism)

## What are the changes implemented in this PR?
* introduce the parallel option that allows modifying the server query parallelism settings.

