### PR TITLE
Add 'get_type' to local Thing concepts

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -19,6 +19,6 @@
 
 build --incompatible_strict_action_env
 run --incompatible_strict_action_env
-test --incompatible_strict_action_env --test_env=PATH
+test --incompatible_strict_action_env --test_env=PATH --cache_test_results=no
 
 try-import /opt/credentials/bazel-remote-cache.rc

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -106,8 +106,7 @@ build:
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
         bazel test //tests/behaviour/graql/language/insert/... --test_output=errors
         bazel test //tests/behaviour/graql/language/delete/... --test_output=errors
-        bazel test //tests/behaviour/graql/language/update:checkstyle --test_output=errors
-        bazel test //tests/behaviour/graql/language/update:test-core --test_output=errors
+        bazel test //tests/behaviour/graql/language/update/... --test_output=errors
     test-behaviour-definable:
       image: graknlabs-ubuntu-20.04
       type: foreground
@@ -121,10 +120,8 @@ build:
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-        bazel test //tests/behaviour/graql/language/define:checkstyle --test_output=errors
-        bazel test //tests/behaviour/graql/language/define:test-core --test_output=errors
-        bazel test //tests/behaviour/graql/language/undefine:checkstyle --test_output=errors
-        bazel test //tests/behaviour/graql/language/undefine:test-core --test_output=errors
+        bazel test //tests/behaviour/graql/language/define/... --test_output=errors
+        bazel test //tests/behaviour/graql/language/undefine/... --test_output=errors
     test-cluster-failover:
       machine: 4-core-8-gb
       image: graknlabs-ubuntu-20.04
@@ -139,7 +136,7 @@ build:
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
-        bazel test //tests:test_cluster_failover --test_output=streamed
+        bazel test //tests:test_cluster_failover --test_output=errors
     deploy-pip-snapshot:
       image: graknlabs-ubuntu-20.04
       dependencies: [build, test-behaviour-connection, test-behaviour-concept, test-behaviour-match, test-behaviour-writable, test-behaviour-definable, test-cluster-failover]

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,7 +27,7 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "c04b5f105914c690cbd54e6bdc6a4eb9dda2b3e7",
+        commit = "8a556849a42a54a0f69277da212540f00b9a783c",
     )
 
 def graknlabs_grakn_cluster_artifacts():
@@ -37,5 +37,5 @@ def graknlabs_grakn_cluster_artifacts():
         artifact_name = "grakn-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "ae8aeb4919887d96aca24aa9029e9827b6437b35",
+        commit = "e1e96cdb1d2c5cfd4309221c5003e7d54a341960",
     )

--- a/grakn/concept/proto/concept_proto_builder.py
+++ b/grakn/concept/proto/concept_proto_builder.py
@@ -33,14 +33,13 @@ def iid(iid_: str):
 def thing(thing_):
     proto_thing = concept_proto.Thing()
     proto_thing.iid = iid(thing_.get_iid())
-    proto_thing.encoding = thing_encoding(thing_)
     return proto_thing
 
 
 def type_(_type):
     proto_type = concept_proto.Type()
     proto_type.label = _type.get_label()
-    proto_type.encoding = type_encoding(_type)
+    proto_type.encoding = encoding(_type)
 
     if _type.is_role_type():
         proto_type.scope = _type.get_scope()
@@ -99,18 +98,7 @@ def value_type(value_type_: ValueType):
         raise GraknClientException("Unrecognised value type: " + str(value_type_))
 
 
-def thing_encoding(thing_):
-    if thing_.is_entity():
-        return concept_proto.Thing.Encoding.Value("ENTITY")
-    elif thing_.is_relation():
-        return concept_proto.Thing.Encoding.Value("RELATION")
-    elif thing_.is_attribute():
-        return concept_proto.Thing.Encoding.Value("ATTRIBUTE")
-    else:
-        raise GraknClientException("Unrecognised thing encoding: " + str(thing_))
-
-
-def type_encoding(_type):
+def encoding(_type):
     if _type.is_entity_type():
         return concept_proto.Type.Encoding.Value("ENTITY_TYPE")
     elif _type.is_relation_type():

--- a/grakn/concept/proto/concept_proto_reader.py
+++ b/grakn/concept/proto/concept_proto_reader.py
@@ -46,29 +46,29 @@ def concept(con_proto: concept_proto.Concept):
 
 
 def thing(thing_proto: concept_proto.Thing):
-    if thing_proto.encoding == concept_proto.Thing.Encoding.Value("ENTITY"):
+    if thing_proto.type.encoding == concept_proto.Type.Encoding.Value("ENTITY_TYPE"):
         return Entity._of(thing_proto)
-    elif thing_proto.encoding == concept_proto.Thing.Encoding.Value("RELATION"):
+    elif thing_proto.type.encoding == concept_proto.Type.Encoding.Value("RELATION_TYPE"):
         return Relation._of(thing_proto)
-    elif thing_proto.encoding == concept_proto.Thing.Encoding.Value("ATTRIBUTE"):
+    elif thing_proto.type.encoding == concept_proto.Type.Encoding.Value("ATTRIBUTE_TYPE"):
         return attribute(thing_proto)
     else:
-        raise GraknClientException("The encoding " + thing_proto.encoding + " was not recognised.")
+        raise GraknClientException("The encoding " + thing_proto.type.encoding + " was not recognised.")
 
 
 def attribute(thing_proto: concept_proto.Thing):
-    if thing_proto.value_type == concept_proto.AttributeType.ValueType.Value("BOOLEAN"):
+    if thing_proto.type.value_type == concept_proto.AttributeType.ValueType.Value("BOOLEAN"):
         return BooleanAttribute._of(thing_proto)
-    elif thing_proto.value_type == concept_proto.AttributeType.ValueType.Value("LONG"):
+    elif thing_proto.type.value_type == concept_proto.AttributeType.ValueType.Value("LONG"):
         return LongAttribute._of(thing_proto)
-    elif thing_proto.value_type == concept_proto.AttributeType.ValueType.Value("DOUBLE"):
+    elif thing_proto.type.value_type == concept_proto.AttributeType.ValueType.Value("DOUBLE"):
         return DoubleAttribute._of(thing_proto)
-    elif thing_proto.value_type == concept_proto.AttributeType.ValueType.Value("STRING"):
+    elif thing_proto.type.value_type == concept_proto.AttributeType.ValueType.Value("STRING"):
         return StringAttribute._of(thing_proto)
-    elif thing_proto.value_type == concept_proto.AttributeType.ValueType.Value("DATETIME"):
+    elif thing_proto.type.value_type == concept_proto.AttributeType.ValueType.Value("DATETIME"):
         return DateTimeAttribute._of(thing_proto)
     else:
-        raise GraknClientException("The value type " + str(thing_proto.value_type) + " was not recognised.")
+        raise GraknClientException("The value type " + str(thing_proto.type.value_type) + " was not recognised.")
 
 
 def type_(type_proto: concept_proto.Type):

--- a/grakn/concept/thing/attribute.py
+++ b/grakn/concept/thing/attribute.py
@@ -16,7 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
 from datetime import datetime
 
 import grakn_protocol.protobuf.concept_pb2 as concept_proto
@@ -26,6 +25,9 @@ from grakn.concept.thing.thing import Thing, RemoteThing
 
 
 class Attribute(Thing):
+
+    def get_value_type(self):
+        return self.get_type().get_value_type()
 
     def is_attribute(self):
         return True
@@ -47,6 +49,9 @@ class Attribute(Thing):
 
 
 class RemoteAttribute(RemoteThing):
+
+    def get_value_type(self):
+        return self.get_type().get_value_type()
 
     def get_owners(self, owner_type=None):
         method = concept_proto.Thing.Req()
@@ -77,13 +82,13 @@ class RemoteAttribute(RemoteThing):
 
 class BooleanAttribute(Attribute):
 
-    def __init__(self, iid: str, value: bool):
-        super(BooleanAttribute, self).__init__(iid)
+    def __init__(self, iid: str, type_, value: bool):
+        super(BooleanAttribute, self).__init__(iid, type_)
         self._value = value
 
     @staticmethod
     def _of(thing_proto: concept_proto.Thing):
-        return BooleanAttribute(concept_proto_reader.iid(thing_proto.iid), thing_proto.value.boolean)
+        return BooleanAttribute(concept_proto_reader.iid(thing_proto.iid), concept_proto_reader.attribute_type(thing_proto.type), thing_proto.value.boolean)
 
     def get_value(self):
         return self._value
@@ -92,13 +97,13 @@ class BooleanAttribute(Attribute):
         return True
 
     def as_remote(self, transaction):
-        return RemoteBooleanAttribute(transaction, self.get_iid(), self.get_value())
+        return RemoteBooleanAttribute(transaction, self.get_iid(), self.get_type(), self.get_value())
 
 
 class RemoteBooleanAttribute(RemoteAttribute):
 
-    def __init__(self, transaction, iid: str, value: bool):
-        super(RemoteBooleanAttribute, self).__init__(transaction, iid)
+    def __init__(self, transaction, iid: str, type_, value: bool):
+        super(RemoteBooleanAttribute, self).__init__(transaction, iid, type_)
         self._value = value
 
     def get_value(self):
@@ -108,18 +113,18 @@ class RemoteBooleanAttribute(RemoteAttribute):
         return True
 
     def as_remote(self, transaction):
-        return RemoteBooleanAttribute(transaction, self.get_iid(), self.get_value())
+        return RemoteBooleanAttribute(transaction, self.get_iid(), self.get_type(), self.get_value())
 
 
 class LongAttribute(Attribute):
 
-    def __init__(self, iid: str, value: int):
-        super(LongAttribute, self).__init__(iid)
+    def __init__(self, iid: str, type_, value: int):
+        super(LongAttribute, self).__init__(iid, type_)
         self._value = value
 
     @staticmethod
     def _of(thing_proto: concept_proto.Thing):
-        return LongAttribute(concept_proto_reader.iid(thing_proto.iid), thing_proto.value.long)
+        return LongAttribute(concept_proto_reader.iid(thing_proto.iid), concept_proto_reader.attribute_type(thing_proto.type), thing_proto.value.long)
 
     def get_value(self):
         return self._value
@@ -128,13 +133,13 @@ class LongAttribute(Attribute):
         return True
 
     def as_remote(self, transaction):
-        return RemoteLongAttribute(transaction, self.get_iid(), self.get_value())
+        return RemoteLongAttribute(transaction, self.get_iid(), self.get_type(), self.get_value())
 
 
 class RemoteLongAttribute(RemoteAttribute):
 
-    def __init__(self, transaction, iid: str, value: int):
-        super(RemoteLongAttribute, self).__init__(transaction, iid)
+    def __init__(self, transaction, iid: str, type_, value: int):
+        super(RemoteLongAttribute, self).__init__(transaction, iid, type_)
         self._value = value
 
     def get_value(self):
@@ -144,18 +149,18 @@ class RemoteLongAttribute(RemoteAttribute):
         return True
 
     def as_remote(self, transaction):
-        return RemoteLongAttribute(transaction, self.get_iid(), self.get_value())
+        return RemoteLongAttribute(transaction, self.get_iid(), self.get_type(), self.get_value())
 
 
 class DoubleAttribute(Attribute):
 
-    def __init__(self, iid: str, value: float):
-        super(DoubleAttribute, self).__init__(iid)
+    def __init__(self, iid: str, type_, value: float):
+        super(DoubleAttribute, self).__init__(iid, type_)
         self._value = value
 
     @staticmethod
     def _of(thing_proto: concept_proto.Thing):
-        return DoubleAttribute(concept_proto_reader.iid(thing_proto.iid), thing_proto.value.double)
+        return DoubleAttribute(concept_proto_reader.iid(thing_proto.iid), concept_proto_reader.attribute_type(thing_proto.type), thing_proto.value.double)
 
     def get_value(self):
         return self._value
@@ -164,13 +169,13 @@ class DoubleAttribute(Attribute):
         return True
 
     def as_remote(self, transaction):
-        return RemoteDoubleAttribute(transaction, self.get_iid(), self.get_value())
+        return RemoteDoubleAttribute(transaction, self.get_iid(), self.get_type(), self.get_value())
 
 
 class RemoteDoubleAttribute(RemoteAttribute):
 
-    def __init__(self, transaction, iid: str, value: float):
-        super(RemoteDoubleAttribute, self).__init__(transaction, iid)
+    def __init__(self, transaction, iid: str, type_, value: float):
+        super(RemoteDoubleAttribute, self).__init__(transaction, iid, type_)
         self._value = value
 
     def get_value(self):
@@ -180,18 +185,18 @@ class RemoteDoubleAttribute(RemoteAttribute):
         return True
 
     def as_remote(self, transaction):
-        return RemoteDoubleAttribute(transaction, self.get_iid(), self.get_value())
+        return RemoteDoubleAttribute(transaction, self.get_iid(), self.get_type(), self.get_value())
 
 
 class StringAttribute(Attribute):
 
-    def __init__(self, iid: str, value: str):
-        super(StringAttribute, self).__init__(iid)
+    def __init__(self, iid: str, type_, value: str):
+        super(StringAttribute, self).__init__(iid, type_)
         self._value = value
 
     @staticmethod
     def _of(thing_proto: concept_proto.Thing):
-        return StringAttribute(concept_proto_reader.iid(thing_proto.iid), thing_proto.value.string)
+        return StringAttribute(concept_proto_reader.iid(thing_proto.iid), concept_proto_reader.attribute_type(thing_proto.type), thing_proto.value.string)
 
     def get_value(self):
         return self._value
@@ -200,13 +205,13 @@ class StringAttribute(Attribute):
         return True
 
     def as_remote(self, transaction):
-        return RemoteStringAttribute(transaction, self.get_iid(), self.get_value())
+        return RemoteStringAttribute(transaction, self.get_iid(), self.get_type(), self.get_value())
 
 
 class RemoteStringAttribute(RemoteAttribute):
 
-    def __init__(self, transaction, iid: str, value: str):
-        super(RemoteStringAttribute, self).__init__(transaction, iid)
+    def __init__(self, transaction, iid: str, type_, value: str):
+        super(RemoteStringAttribute, self).__init__(transaction, iid, type_)
         self._value = value
 
     def get_value(self):
@@ -216,18 +221,18 @@ class RemoteStringAttribute(RemoteAttribute):
         return True
 
     def as_remote(self, transaction):
-        return RemoteStringAttribute(transaction, self.get_iid(), self.get_value())
+        return RemoteStringAttribute(transaction, self.get_iid(), self.get_type(), self.get_value())
 
 
 class DateTimeAttribute(Attribute):
 
-    def __init__(self, iid: str, value: datetime):
-        super(DateTimeAttribute, self).__init__(iid)
+    def __init__(self, iid: str, type_, value: datetime):
+        super(DateTimeAttribute, self).__init__(iid, type_)
         self._value = value
 
     @staticmethod
     def _of(thing_proto: concept_proto.Thing):
-        return DateTimeAttribute(concept_proto_reader.iid(thing_proto.iid), datetime.fromtimestamp(float(thing_proto.value.date_time) / 1000.0))
+        return DateTimeAttribute(concept_proto_reader.iid(thing_proto.iid), concept_proto_reader.attribute_type(thing_proto.type), datetime.fromtimestamp(float(thing_proto.value.date_time) / 1000.0))
 
     def get_value(self):
         return self._value
@@ -236,13 +241,13 @@ class DateTimeAttribute(Attribute):
         return True
 
     def as_remote(self, transaction):
-        return RemoteDateTimeAttribute(transaction, self.get_iid(), self.get_value())
+        return RemoteDateTimeAttribute(transaction, self.get_iid(), self.get_type(), self.get_value())
 
 
 class RemoteDateTimeAttribute(RemoteAttribute):
 
-    def __init__(self, transaction, iid: str, value: datetime):
-        super(RemoteDateTimeAttribute, self).__init__(transaction, iid)
+    def __init__(self, transaction, iid: str, type_, value: datetime):
+        super(RemoteDateTimeAttribute, self).__init__(transaction, iid, type_)
         self._value = value
 
     def get_value(self):
@@ -252,4 +257,4 @@ class RemoteDateTimeAttribute(RemoteAttribute):
         return True
 
     def as_remote(self, transaction):
-        return RemoteDateTimeAttribute(transaction, self.get_iid(), self.get_value())
+        return RemoteDateTimeAttribute(transaction, self.get_iid(), self.get_type(), self.get_value())

--- a/grakn/concept/thing/attribute.py
+++ b/grakn/concept/thing/attribute.py
@@ -26,9 +26,6 @@ from grakn.concept.thing.thing import Thing, RemoteThing
 
 class Attribute(Thing):
 
-    def get_value_type(self):
-        return self.get_type().get_value_type()
-
     def is_attribute(self):
         return True
 
@@ -49,9 +46,6 @@ class Attribute(Thing):
 
 
 class RemoteAttribute(RemoteThing):
-
-    def get_value_type(self):
-        return self.get_type().get_value_type()
 
     def get_owners(self, owner_type=None):
         method = concept_proto.Thing.Req()

--- a/grakn/concept/thing/entity.py
+++ b/grakn/concept/thing/entity.py
@@ -27,10 +27,10 @@ class Entity(Thing):
 
     @staticmethod
     def _of(thing_proto: concept_proto.Thing):
-        return Entity(concept_proto_reader.iid(thing_proto.iid))
+        return Entity(concept_proto_reader.iid(thing_proto.iid), concept_proto_reader.type_(thing_proto.type))
 
     def as_remote(self, transaction):
-        return RemoteEntity(transaction, self._iid)
+        return RemoteEntity(transaction, self._iid, self.get_type())
 
     def is_entity(self):
         return True
@@ -39,7 +39,7 @@ class Entity(Thing):
 class RemoteEntity(RemoteThing):
 
     def as_remote(self, transaction):
-        return RemoteEntity(transaction, self._iid)
+        return RemoteEntity(transaction, self._iid, self.get_type())
 
     def is_entity(self):
         return True

--- a/grakn/concept/thing/relation.py
+++ b/grakn/concept/thing/relation.py
@@ -28,10 +28,10 @@ class Relation(Thing):
 
     @staticmethod
     def _of(thing_proto: concept_proto.Thing):
-        return Relation(concept_proto_reader.iid(thing_proto.iid))
+        return Relation(concept_proto_reader.iid(thing_proto.iid), concept_proto_reader.type_(thing_proto.type))
 
     def as_remote(self, transaction):
-        return RemoteRelation(transaction, self.get_iid())
+        return RemoteRelation(transaction, self.get_iid(), self.get_type())
 
     def is_relation(self):
         return True
@@ -40,7 +40,7 @@ class Relation(Thing):
 class RemoteRelation(RemoteThing):
 
     def as_remote(self, transaction):
-        return RemoteRelation(transaction, self.get_iid())
+        return RemoteRelation(transaction, self.get_iid(), self.get_type())
 
     def get_players_by_role_type(self):
         method = concept_proto.Thing.Req()

--- a/grakn/concept/thing/thing.py
+++ b/grakn/concept/thing/thing.py
@@ -29,14 +29,18 @@ from grakn.concept.concept import Concept, RemoteConcept
 
 class Thing(Concept):
 
-    def __init__(self, iid: str):
+    def __init__(self, iid: str, type_):
         if not iid:
             raise GraknClientException("IID must be a non-empty string.")
         self._iid = iid
+        self._type = type_
         self._hash = hash(iid)
 
     def get_iid(self):
         return self._iid
+
+    def get_type(self):
+        return self._type
 
     def is_thing(self):
         return True
@@ -57,22 +61,21 @@ class Thing(Concept):
 
 class RemoteThing(RemoteConcept):
 
-    def __init__(self, transaction, iid: str):
+    def __init__(self, transaction, iid: str, type_):
         if not transaction:
             raise GraknClientException("Transaction must be set.")
         if not iid:
             raise GraknClientException("IID must be set.")
         self._transaction = transaction
         self._iid = iid
+        self._type = type_
         self._hash = hash(iid)
 
     def get_iid(self):
         return self._iid
 
     def get_type(self):
-        method = concept_proto.Thing.Req()
-        method.thing_get_type_req.CopyFrom(concept_proto.Thing.GetType.Req())
-        return concept_proto_reader.type_(self._execute(method).thing_get_type_res.thing_type)
+        return self._type
 
     def is_inferred(self):
         req = concept_proto.Thing.Req()

--- a/grakn/rpc/cluster/failsafe_task.py
+++ b/grakn/rpc/cluster/failsafe_task.py
@@ -63,7 +63,7 @@ class _FailsafeTask(ABC):
             except RpcError as e:
                 # TODO: this logic should be extracted into GraknClientException
                 # TODO: error message should be checked in a less brittle way
-                if e.code() == StatusCode.UNAVAILABLE or "[INT07]" in str(e) or "Received RST_STREAM" in str(e):
+                if e.code() in [StatusCode.UNAVAILABLE, StatusCode.UNKNOWN] or "[INT07]" in str(e) or "Received RST_STREAM" in str(e):
                     print("Unable to open a session or transaction, retrying in 2s... %s" % str(e))
                     time.sleep(self.WAIT_FOR_PRIMARY_REPLICA_SELECTION_SECONDS)
                     replica = self._seek_primary_replica()
@@ -85,7 +85,7 @@ class _FailsafeTask(ABC):
             try:
                 return self.run(replica) if retries == 0 else self.rerun(replica)
             except RpcError as e:
-                if e.code() == StatusCode.UNAVAILABLE or "[INT07]" in str(e) or "Received RST_STREAM" in str(e):
+                if e.code() in [StatusCode.UNAVAILABLE, StatusCode.UNKNOWN] or "[INT07]" in str(e) or "Received RST_STREAM" in str(e):
                     print("Unable to open a session or transaction to %s. Attempting next replica. %s" % (str(replica.replica_id()), str(e)))
                 else:
                     raise e

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,6 @@
 ## Dependencies
 
 # IMPORTANT: Any changes to these dependencies should be copied to requirements_dev.txt.
-grakn-protocol==2.0.0a11
+grakn-protocol==0.0.0-aa53efa4131bc7397efcf29375d2db6eab760df4
 grpcio==1.35.0
 protobuf==3.14.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -28,7 +28,7 @@
 
 ## Dependencies
 
-grakn-protocol==2.0.0a11
+grakn-protocol==0.0.0-aa53efa4131bc7397efcf29375d2db6eab760df4
 grpcio==1.35.0
 protobuf==3.14.0
 

--- a/tests/behaviour/concept/thing/attribute/attribute_steps.py
+++ b/tests/behaviour/concept/thing/attribute/attribute_steps.py
@@ -48,7 +48,7 @@ def step_impl(context: Context, var1: str, var2: str):
 
 @step("attribute {var:Var} has value type: {value_type:ValueType}")
 def step_impl(context: Context, var: str, value_type: ValueType):
-    assert_that(context.get(var).get_value_type(), is_(value_type))
+    assert_that(context.get(var).get_type().get_value_type(), is_(value_type))
 
 
 @step("attribute({type_label}) as(boolean) put: {value:Bool}; throws exception")

--- a/tests/behaviour/concept/thing/attribute/attribute_steps.py
+++ b/tests/behaviour/concept/thing/attribute/attribute_steps.py
@@ -48,7 +48,7 @@ def step_impl(context: Context, var1: str, var2: str):
 
 @step("attribute {var:Var} has value type: {value_type:ValueType}")
 def step_impl(context: Context, var: str, value_type: ValueType):
-    assert_that(context.get(var).as_remote(context.tx()).get_type().get_value_type(), is_(value_type))
+    assert_that(context.get(var).get_value_type(), is_(value_type))
 
 
 @step("attribute({type_label}) as(boolean) put: {value:Bool}; throws exception")

--- a/tests/behaviour/concept/thing/entity/entity_steps.py
+++ b/tests/behaviour/concept/thing/entity/entity_steps.py
@@ -46,7 +46,7 @@ def step_impl(context: Context, var: str, type_label: str, key_type: str, key_va
 def step_impl(context: Context, var: str, type_label: str, key_type: str, key_value: str):
     context.put(var, next((owner for owner in context.tx().concepts().get_attribute_type(key_type).as_string()
                           .as_remote(context.tx()).get(key_value).as_remote(context.tx()).get_owners()
-                           if owner.as_remote(context.tx()).get_type() == context.tx().concepts().get_entity_type(type_label)), None))
+                           if owner.get_type().get_label() == type_label), None))
 
 
 @step("entity({type_label}) get instances contain: {var:Var}")

--- a/tests/behaviour/concept/thing/relation/relation_steps.py
+++ b/tests/behaviour/concept/thing/relation/relation_steps.py
@@ -49,7 +49,7 @@ def step_impl(context: Context, var: str, type_label: str, key_type: str, key_va
 def step_impl(context: Context, var: str, type_label: str, key_type: str, key_value: str):
     context.put(var, next((owner for owner in context.tx().concepts().get_attribute_type(key_type).as_string()
                           .as_remote(context.tx()).get(key_value).as_remote(context.tx()).get_owners()
-                           if owner.as_remote(context.tx()).get_type() == context.tx().concepts().get_relation_type(type_label)), None))
+                           if owner.get_type().get_label() == type_label), None))
 
 
 @step("relation({type_label}) get instances contain: {var:Var}")
@@ -69,26 +69,27 @@ def step_impl(context: Context, type_label: str):
 
 @step("relation {var1:Var} add player for role({role_label}): {var2:Var}")
 def step_impl(context: Context, var1: str, role_label: str, var2: str):
-    context.get(var1).as_remote(context.tx()).add_player(context.get(var1).as_remote(context.tx()).get_type().as_remote(context.tx()).get_relates(role_label), context.get(var2))
+    context.get(var1).as_remote(context.tx()).add_player(context.get(var1).get_type().as_remote(context.tx()).get_relates(role_label), context.get(var2))
 
 
 @step("relation {var1:Var} remove player for role({role_label}): {var2:Var}")
 def step_impl(context: Context, var1: str, role_label: str, var2: str):
-    context.get(var1).as_remote(context.tx()).remove_player(context.get(var1).as_remote(context.tx()).get_type().as_remote(context.tx()).get_relates(role_label), context.get(var2))
+    context.get(var1).as_remote(context.tx()).remove_player(context.get(var1).get_type().as_remote(context.tx()).get_relates(role_label), context.get(var2))
+
 
 @step("relation {var1:Var} add player for role({role_label}): {var2:Var}; throws exception")
 def step_impl(context: Context, var1: str, role_label: str, var2: str):
     adding_player_throws_exception(context, var1, role_label, var2)
 
+
 def adding_player_throws_exception(context: Context, var1: str, role_label: str, var2: str):
     try:
         context.get(var1).as_remote(context.tx()).add_player(
-            context.get(var1).as_remote(context.tx()).get_type().as_remote(context.tx()).get_relates(role_label),
+            context.get(var1).get_type().as_remote(context.tx()).get_relates(role_label),
             context.get(var2))
         assert False;
     except GraknClientException:
         pass
-
 
 
 @step("relation {var:Var} get players contain")
@@ -98,7 +99,7 @@ def step_impl(context: Context, var: str):
     players_by_role_type = relation.as_remote(context.tx()).get_players_by_role_type()
     print(players)
     for (role_label, var2) in players.items():
-        assert_that(players_by_role_type.get(relation.as_remote(context.tx()).get_type().as_remote(context.tx()).get_relates(role_label)), has_item(context.get(parse_var(var2))))
+        assert_that(players_by_role_type.get(relation.get_type().as_remote(context.tx()).get_relates(role_label)), has_item(context.get(parse_var(var2))))
 
 
 @step("relation {var:Var} get players do not contain")
@@ -107,7 +108,7 @@ def step_impl(context: Context, var: str):
     relation = context.get(var)
     players_by_role_type = relation.as_remote(context.tx()).get_players_by_role_type()
     for (role_label, var2) in players.items():
-        assert_that(players_by_role_type.get(relation.as_remote(context.tx()).get_type().as_remote(context.tx()).get_relates(role_label)), not_(has_item(context.get(parse_var(var2)))))
+        assert_that(players_by_role_type.get(relation.get_type().as_remote(context.tx()).get_relates(role_label)), not_(has_item(context.get(parse_var(var2)))))
 
 
 @step("relation {var1:Var} get players contain: {var2:Var}")
@@ -123,12 +124,12 @@ def step_impl(context: Context, var1: str, var2: str):
 @step("relation {var1:Var} get players for role({role_label}) contain: {var2:Var}")
 def step_impl(context: Context, var1: str, role_label: str, var2: str):
     assert_that(context.get(var1).as_remote(context.tx()).get_players(
-        role_types=[context.get(var1).as_remote(context.tx()).get_type().as_remote(context.tx()).get_relates(role_label)]),
+        role_types=[context.get(var1).get_type().as_remote(context.tx()).get_relates(role_label)]),
         has_item(context.get(var2)))
 
 
 @step("relation {var1:Var} get players for role({role_label}) do not contain: {var2:Var}")
 def step_impl(context: Context, var1: str, role_label: str, var2: str):
     assert_that(context.get(var1).as_remote(context.tx()).get_players(
-        role_types=[context.get(var1).as_remote(context.tx()).get_type().as_remote(context.tx()).get_relates(role_label)]),
+        role_types=[context.get(var1).get_type().as_remote(context.tx()).get_relates(role_label)]),
         not_(has_item(context.get(var2))))

--- a/tests/behaviour/concept/thing/thing_steps.py
+++ b/tests/behaviour/concept/thing/thing_steps.py
@@ -44,7 +44,7 @@ def step_impl(context: Context, var: str, is_deleted):
 @step("{root_label:RootLabel} {var:Var} has type: {type_label}")
 def step_impl(context: Context, root_label: RootLabel, var: str, type_label: str):
     thing_type = context.get_thing_type(root_label, type_label)
-    assert_that(context.get(var).as_remote(context.tx()).get_type(), is_(thing_type))
+    assert_that(context.get(var).get_type(), is_(thing_type))
 
 
 @step("delete entity: {var:Var}")

--- a/tests/behaviour/graql/graql_steps.py
+++ b/tests/behaviour/graql/graql_steps.py
@@ -209,7 +209,7 @@ class AttributeValueMatcher(AttributeMatcher):
 
         attribute = concept
 
-        if self.type_label != attribute.as_remote(context.tx()).get_type().get_label():
+        if self.type_label != attribute.get_type().get_label():
             return False
 
         return self.check(attribute)
@@ -224,7 +224,7 @@ class ThingKeyMatcher(AttributeMatcher):
         keys = [key for key in concept.as_remote(context.tx()).get_has(only_key=True)]
 
         for key in keys:
-            if key.as_remote(context.tx()).get_type().get_label() == self.type_label:
+            if key.get_type().get_label() == self.type_label:
                 return self.check(key)
 
         return False


### PR DESCRIPTION
## What is the goal of this PR?

Previously, `get_type` was only available on remote `Thing` concepts. Now, we include type information whenever a Graql query or Concept API method returns a `Thing`, enabling users to use it without an additional network roundtrip per concept.

## What are the changes implemented in this PR?

Add 'get_type' to local Thing concepts