### PR TITLE
Upgrade grpcio to 1.36.1, protobuf to 3.15.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,5 +31,5 @@
 
 # IMPORTANT: Any changes to these dependencies should be copied to requirements_dev.txt.
 grakn-protocol==2.0.0a12
-grpcio==1.35.0
-protobuf==3.14.0
+grpcio==1.36.1
+protobuf==3.15.5

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -29,8 +29,8 @@
 ## Dependencies
 
 grakn-protocol==2.0.0a12
-grpcio==1.35.0
-protobuf==3.14.0
+grpcio==1.36.1
+protobuf==3.15.5
 
 
 # Dev dependencies (not required to use the grakn-client package, but necessary for its development)


### PR DESCRIPTION
## What is the goal of this PR?

We upgraded grpcio and protobuf to remove warnings when running Python 3.9.

## What are the changes implemented in this PR?

Upgrade grpcio to 1.36.1, protobuf to 3.15.5