### PR TITLE
Add prefetch, session, schema lock timeout options

### DIFF
--- a/grakn/options.py
+++ b/grakn/options.py
@@ -28,6 +28,9 @@ class GraknOptions(ABC):
         self.explain: Optional[bool] = None
         self.parallel: Optional[bool] = None
         self.batch_size: Optional[int] = None
+        self.prefetch: Optional[bool] = None
+        self.session_idle_timeout_millis: Optional[int] = None
+        self.schema_lock_acquire_timeout_millis: Optional[int] = None
 
     @staticmethod
     def core() -> "GraknOptions":

--- a/grakn/options_proto_builder.py
+++ b/grakn/options_proto_builder.py
@@ -25,6 +25,7 @@ from grakn.options import GraknOptions, GraknClusterOptions
 
 def options(opts: Union[GraknOptions, GraknClusterOptions]):
     proto_options = options_proto.Options()
+
     if opts.infer is not None:
         proto_options.infer = opts.infer
     if opts.trace_inference is not None:
@@ -35,6 +36,14 @@ def options(opts: Union[GraknOptions, GraknClusterOptions]):
         proto_options.parallel = opts.parallel
     if opts.batch_size is not None:
         proto_options.batch_size = opts.batch_size
+    if opts.prefetch is not None:
+        proto_options.prefetch = opts.prefetch
+    if opts.session_idle_timeout_millis is not None:
+        proto_options.session_idle_timeout_millis = opts.session_idle_timeout_millis
+    if opts.schema_lock_acquire_timeout_millis is not None:
+        proto_options.schema_lock_acquire_timeout_millis = opts.schema_lock_acquire_timeout_millis
+
     if opts.is_cluster() and opts.read_any_replica is not None:
         proto_options.read_any_replica = opts.read_any_replica
+
     return proto_options

--- a/grakn/query/query_manager.py
+++ b/grakn/query/query_manager.py
@@ -22,7 +22,7 @@ from typing import Callable, List
 import grakn_protocol.protobuf.query_pb2 as query_proto
 import grakn_protocol.protobuf.transaction_pb2 as transaction_proto
 
-from grakn import grakn_proto_builder
+from grakn import options_proto_builder
 from grakn.concept.answer import concept_map, concept_map_group, numeric, numeric_group
 from grakn.options import GraknOptions
 
@@ -121,6 +121,6 @@ class QueryManager:
 
     def _iterate_query(self, query_req: query_proto.Query.Req, response_reader: Callable[[transaction_proto.Transaction.Res], List], options: GraknOptions):
         req = transaction_proto.Transaction.Req()
-        query_req.options.CopyFrom(grakn_proto_builder.options(options))
+        query_req.options.CopyFrom(options_proto_builder.options(options))
         req.query_req.CopyFrom(query_req)
         return self._transaction._stream(req, response_reader)

--- a/grakn/rpc/session.py
+++ b/grakn/rpc/session.py
@@ -26,7 +26,7 @@ import grakn_protocol.protobuf.session_pb2 as session_proto
 import grpc
 from grakn_protocol.protobuf.grakn_pb2_grpc import GraknStub
 
-from grakn import grakn_proto_builder
+from grakn import options_proto_builder
 from grakn.options import GraknOptions
 from grakn.rpc.database import Database, _DatabaseRPC
 from grakn.rpc.transaction import Transaction, TransactionType
@@ -93,7 +93,7 @@ class _SessionRPC(Session):
         open_req = session_proto.Session.Open.Req()
         open_req.database = database
         open_req.type = _session_type_proto(session_type)
-        open_req.options.CopyFrom(grakn_proto_builder.options(options))
+        open_req.options.CopyFrom(options_proto_builder.options(options))
 
         self._session_id: bytes = self._grpc_stub.session_open(open_req).session_id
         self._is_open = True

--- a/grakn/rpc/transaction.py
+++ b/grakn/rpc/transaction.py
@@ -29,7 +29,7 @@ import queue
 from grakn_protocol.protobuf.grakn_pb2_grpc import GraknStub
 import grakn_protocol.protobuf.transaction_pb2 as transaction_proto
 
-from grakn import grakn_proto_builder
+from grakn import options_proto_builder
 from grakn.common.exception import GraknClientException
 from grakn.concept.concept_manager import ConceptManager
 from grakn.options import GraknOptions
@@ -62,7 +62,7 @@ class Transaction:
         open_req = transaction_proto.Transaction.Open.Req()
         open_req.session_id = session_id
         open_req.type = Transaction._transaction_type_proto(transaction_type)
-        open_req.options.CopyFrom(grakn_proto_builder.options(options))
+        open_req.options.CopyFrom(options_proto_builder.options(options))
         req = transaction_proto.Transaction.Req()
         req.open_req.CopyFrom(open_req)
 


### PR DESCRIPTION
## What is the goal of this PR?

We added three new `GraknOptions`: `prefetch`, `session_idle_timeout_millis` and `schema_lock_acquire_timeout_millis`.

## What are the changes implemented in this PR?

Add prefetch, session, schema lock timeout options