### PR TITLE
On transaction failover, transfer options to the new session

### DIFF
--- a/grakn/rpc/cluster/session.py
+++ b/grakn/rpc/cluster/session.py
@@ -33,6 +33,7 @@ class SessionClusterRPC(Session):
         self.core_client = cluster_client.core_client(server_address)
         print("Opening a session to %s" % server_address)
         self.core_session = self.core_client.session(database, session_type, options)
+        self.options = options
 
     def transaction(self, transaction_type: TransactionType, options: GraknClusterOptions = None) -> Transaction:
         if not options:
@@ -79,5 +80,5 @@ class TransactionFailsafeTask(_FailsafeTask):
         if self.cluster_session.core_session:
             self.cluster_session.core_session.close()
         self.cluster_session.core_client = self.cluster_session.cluster_client.core_client(replica.address())
-        self.cluster_session.core_session = self.cluster_session.core_client.session(self.database, self.cluster_session.session_type(), self.options)
+        self.cluster_session.core_session = self.cluster_session.core_client.session(self.database, self.cluster_session.session_type(), self.cluster_session.options)
         return self.cluster_session.core_session.transaction(self.transaction_type, self.options)

--- a/grakn/rpc/cluster/session.py
+++ b/grakn/rpc/cluster/session.py
@@ -33,7 +33,7 @@ class SessionClusterRPC(Session):
         self.core_client = cluster_client.core_client(server_address)
         print("Opening a session to %s" % server_address)
         self.core_session = self.core_client.session(database, session_type, options)
-        self.options = options
+        self._options = options
 
     def transaction(self, transaction_type: TransactionType, options: GraknClusterOptions = None) -> Transaction:
         if not options:
@@ -48,6 +48,9 @@ class SessionClusterRPC(Session):
 
     def session_type(self) -> SessionType:
         return self.core_session.session_type()
+
+    def options(self) -> GraknClusterOptions:
+        return self._options
 
     def is_open(self) -> bool:
         return self.core_session.is_open()
@@ -80,5 +83,5 @@ class TransactionFailsafeTask(_FailsafeTask):
         if self.cluster_session.core_session:
             self.cluster_session.core_session.close()
         self.cluster_session.core_client = self.cluster_session.cluster_client.core_client(replica.address())
-        self.cluster_session.core_session = self.cluster_session.core_client.session(self.database, self.cluster_session.session_type(), self.cluster_session.options)
+        self.cluster_session.core_session = self.cluster_session.core_client.session(self.database, self.cluster_session.session_type(), self.cluster_session.options())
         return self.cluster_session.core_session.transaction(self.transaction_type, self.options)

--- a/grakn/rpc/session.py
+++ b/grakn/rpc/session.py
@@ -55,6 +55,10 @@ class Session(ABC):
         pass
 
     @abstractmethod
+    def options(self) -> GraknOptions:
+        pass
+
+    @abstractmethod
     def is_open(self) -> bool:
         pass
 
@@ -87,6 +91,7 @@ class _SessionRPC(Session):
         self._scheduler = sched.scheduler(time.time, time.sleep)
         self._database = _DatabaseRPC(database_manager=client.databases(), name=database)
         self._session_type = session_type
+        self._options = options
         self._grpc_stub = GraknStub(self._channel)
         self._lock = Lock()
 
@@ -107,6 +112,9 @@ class _SessionRPC(Session):
 
     def session_type(self) -> SessionType:
         return self._session_type
+
+    def options(self) -> GraknOptions:
+        return self._options
 
     def is_open(self) -> bool:
         return self._is_open


### PR DESCRIPTION
## What is the goal of this PR?

Previously, when opening a Transaction to Grakn Cluster failed (causing a new Session to be opened to a new server), the old Session options were discarded. Now, we properly transfer the Session-level options to the new session.

## What are the changes implemented in this PR?

On transaction failover, transfer options to the new session