### PR TITLE
Shorten enum names to SessionType, TransactionType

### DIFF
--- a/grakn/api/client.py
+++ b/grakn/api/client.py
@@ -20,7 +20,7 @@ from abc import ABC, abstractmethod
 
 from grakn.api.database import DatabaseManager, ClusterDatabaseManager
 from grakn.api.options import GraknOptions
-from grakn.api.session import GraknSession
+from grakn.api.session import GraknSession, SessionType
 
 
 class GraknClient(ABC):
@@ -34,7 +34,7 @@ class GraknClient(ABC):
         pass
 
     @abstractmethod
-    def session(self, database: str, session_type: GraknSession.Type, options: GraknOptions = None) -> GraknSession:
+    def session(self, database: str, session_type: SessionType, options: GraknOptions = None) -> GraknSession:
         pass
 
     @abstractmethod

--- a/grakn/api/session.py
+++ b/grakn/api/session.py
@@ -23,7 +23,21 @@ import grakn_protocol.common.session_pb2 as session_proto
 
 from grakn.api.database import Database
 from grakn.api.options import GraknOptions
-from grakn.api.transaction import GraknTransaction
+from grakn.api.transaction import GraknTransaction, TransactionType
+
+
+class SessionType(enum.Enum):
+    DATA = 0
+    SCHEMA = 1
+
+    def is_data(self):
+        return self is SessionType.DATA
+
+    def is_schema(self):
+        return self is SessionType.SCHEMA
+
+    def proto(self):
+        return session_proto.Session.Type.Value(self.name)
 
 
 class GraknSession(ABC):
@@ -33,7 +47,7 @@ class GraknSession(ABC):
         pass
 
     @abstractmethod
-    def session_type(self) -> "Type":
+    def session_type(self) -> "SessionType":
         pass
 
     @abstractmethod
@@ -45,7 +59,7 @@ class GraknSession(ABC):
         pass
 
     @abstractmethod
-    def transaction(self, transaction_type: GraknTransaction.Type, options: GraknOptions = None) -> GraknTransaction:
+    def transaction(self, transaction_type: TransactionType, options: GraknOptions = None) -> GraknTransaction:
         pass
 
     @abstractmethod
@@ -59,16 +73,3 @@ class GraknSession(ABC):
     @abstractmethod
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
-
-    class Type(enum.Enum):
-        DATA = 0
-        SCHEMA = 1
-
-        def is_data(self):
-            return self is GraknSession.Type.DATA
-
-        def is_schema(self):
-            return self is GraknSession.Type.SCHEMA
-
-        def proto(self):
-            return session_proto.Session.Type.Value(self.name)

--- a/grakn/api/transaction.py
+++ b/grakn/api/transaction.py
@@ -30,6 +30,20 @@ from grakn.api.query.future import QueryFuture
 from grakn.api.query.query_manager import QueryManager
 
 
+class TransactionType(enum.Enum):
+    READ = 0
+    WRITE = 1
+
+    def is_read(self):
+        return self is TransactionType.READ
+
+    def is_write(self):
+        return self is TransactionType.WRITE
+
+    def proto(self):
+        return transaction_proto.Transaction.Type.Value(self.name)
+
+
 class GraknTransaction(ABC):
 
     @abstractmethod
@@ -37,7 +51,7 @@ class GraknTransaction(ABC):
         pass
 
     @abstractmethod
-    def transaction_type(self) -> "Type":
+    def transaction_type(self) -> TransactionType:
         pass
 
     @abstractmethod
@@ -75,19 +89,6 @@ class GraknTransaction(ABC):
     @abstractmethod
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
-
-    class Type(enum.Enum):
-        READ = 0
-        WRITE = 1
-
-        def is_read(self):
-            return self is GraknTransaction.Type.READ
-
-        def is_write(self):
-            return self is GraknTransaction.Type.WRITE
-
-        def proto(self):
-            return transaction_proto.Transaction.Type.Value(self.name)
 
 
 class _GraknTransactionExtended(GraknTransaction, ABC):

--- a/grakn/client.py
+++ b/grakn/client.py
@@ -24,8 +24,8 @@ from grakn.core.client import _CoreClient
 
 # Repackaging these symbols allows them to be imported from "grakn.client"
 from grakn.api.options import GraknOptions  # noqa # pylint: disable=unused-import
-from grakn.api.session import GraknSession  # noqa # pylint: disable=unused-import
-from grakn.api.transaction import GraknTransaction  # noqa # pylint: disable=unused-import
+from grakn.api.session import GraknSession, SessionType  # noqa # pylint: disable=unused-import
+from grakn.api.transaction import GraknTransaction, TransactionType  # noqa # pylint: disable=unused-import
 
 
 class Grakn:

--- a/grakn/cluster/client.py
+++ b/grakn/cluster/client.py
@@ -20,7 +20,7 @@ from typing import Iterable, Dict, Set
 
 from grakn.api.client import GraknClusterClient
 from grakn.api.options import GraknOptions, GraknClusterOptions
-from grakn.api.session import GraknSession
+from grakn.api.session import SessionType
 from grakn.cluster.database import _ClusterDatabase
 from grakn.cluster.database_manager import _ClusterDatabaseManager
 from grakn.cluster.failsafe_task import _FailsafeTask
@@ -64,15 +64,15 @@ class _ClusterClient(GraknClusterClient):
     def databases(self) -> _ClusterDatabaseManager:
         return self._database_managers
 
-    def session(self, database: str, session_type: GraknSession.Type, options=None) -> _ClusterSession:
+    def session(self, database: str, session_type: SessionType, options=None) -> _ClusterSession:
         if not options:
             options = GraknOptions.cluster()
         return self._session_any_replica(database, session_type, options) if options.read_any_replica else self._session_primary_replica(database, session_type, options)
 
-    def _session_primary_replica(self, database: str, session_type: GraknSession.Type, options=None) -> _ClusterSession:
+    def _session_primary_replica(self, database: str, session_type: SessionType, options=None) -> _ClusterSession:
         return _OpenSessionFailsafeTask(database, session_type, options, self).run_primary_replica()
 
-    def _session_any_replica(self, database: str, session_type: GraknSession.Type, options=None) -> _ClusterSession:
+    def _session_any_replica(self, database: str, session_type: SessionType, options=None) -> _ClusterSession:
         return _OpenSessionFailsafeTask(database, session_type, options, self).run_any_replica()
 
     def database_by_name(self) -> Dict[str, _ClusterDatabase]:
@@ -109,7 +109,7 @@ class _ClusterClient(GraknClusterClient):
 
 class _OpenSessionFailsafeTask(_FailsafeTask):
 
-    def __init__(self, database: str, session_type: GraknSession.Type, options: GraknClusterOptions, client: _ClusterClient):
+    def __init__(self, database: str, session_type: SessionType, options: GraknClusterOptions, client: _ClusterClient):
         super().__init__(client, database)
         self.session_type = session_type
         self.options = options

--- a/grakn/core/client.py
+++ b/grakn/core/client.py
@@ -22,7 +22,7 @@ from grpc import insecure_channel, Channel
 
 from grakn.api.client import GraknClient
 from grakn.api.options import GraknOptions
-from grakn.api.session import GraknSession
+from grakn.api.session import SessionType
 from grakn.common.rpc.stub import GraknCoreStub
 from grakn.core.database_manager import _CoreDatabaseManager
 from grakn.core.session import _CoreSession
@@ -41,7 +41,7 @@ class _CoreClient(GraknClient):
         self._sessions: Dict[bytes, _CoreSession] = {}
         self._is_open = True
 
-    def session(self, database: str, session_type: GraknSession.Type, options=None) -> _CoreSession:
+    def session(self, database: str, session_type: SessionType, options=None) -> _CoreSession:
         if not options:
             options = GraknOptions.core()
         session = _CoreSession(self, database, session_type, options)

--- a/grakn/core/session.py
+++ b/grakn/core/session.py
@@ -25,8 +25,8 @@ import grakn_protocol.common.session_pb2 as session_proto
 from grpc import RpcError
 
 from grakn.api.options import GraknOptions
-from grakn.api.session import GraknSession
-from grakn.api.transaction import GraknTransaction
+from grakn.api.session import GraknSession, SessionType
+from grakn.api.transaction import GraknTransaction, TransactionType
 from grakn.common.concurrent.atomic import AtomicBoolean
 from grakn.common.concurrent.lock import ReadWriteLock
 from grakn.common.rpc.request_builder import session_open_req
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 class _CoreSession(GraknSession):
     _PULSE_INTERVAL_SECONDS = 5
 
-    def __init__(self, client: "_CoreClient", database: str, session_type: GraknSession.Type, options: GraknOptions = None):
+    def __init__(self, client: "_CoreClient", database: str, session_type: SessionType, options: GraknOptions = None):
         if not options:
             options = GraknOptions.core()
         self._client = client
@@ -66,7 +66,7 @@ class _CoreSession(GraknSession):
     def is_open(self) -> bool:
         return self._is_open.get()
 
-    def session_type(self) -> GraknSession.Type:
+    def session_type(self) -> SessionType:
         return self._session_type
 
     def database(self) -> _CoreDatabase:
@@ -75,7 +75,7 @@ class _CoreSession(GraknSession):
     def options(self) -> GraknOptions:
         return self._options
 
-    def transaction(self, transaction_type: GraknTransaction.Type, options: GraknOptions = None) -> GraknTransaction:
+    def transaction(self, transaction_type: TransactionType, options: GraknOptions = None) -> GraknTransaction:
         if not options:
             options = GraknOptions.core()
         try:

--- a/grakn/core/transaction.py
+++ b/grakn/core/transaction.py
@@ -24,7 +24,7 @@ from grpc import insecure_channel, RpcError
 
 from grakn.api.options import GraknOptions
 from grakn.api.query.future import QueryFuture
-from grakn.api.transaction import _GraknTransactionExtended, GraknTransaction
+from grakn.api.transaction import _GraknTransactionExtended, TransactionType
 from grakn.common.exception import GraknClientException, TRANSACTION_CLOSED
 from grakn.common.rpc.request_builder import transaction_commit_req, transaction_rollback_req, transaction_open_req
 from grakn.common.rpc.stub import GraknCoreStub
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 
 class _CoreTransaction(_GraknTransactionExtended):
 
-    def __init__(self, session: "_CoreSession", transaction_type: GraknTransaction.Type, options: GraknOptions = None):
+    def __init__(self, session: "_CoreSession", transaction_type: TransactionType, options: GraknOptions = None):
         if not options:
             options = GraknOptions.core()
         self._transaction_type = transaction_type
@@ -58,7 +58,7 @@ class _CoreTransaction(_GraknTransactionExtended):
         except RpcError as e:
             raise GraknClientException.of_rpc(e)
 
-    def transaction_type(self) -> GraknTransaction.Type:
+    def transaction_type(self) -> TransactionType:
         return self._transaction_type
 
     def options(self) -> GraknOptions:

--- a/tests/behaviour/config/parameters.py
+++ b/tests/behaviour/config/parameters.py
@@ -26,7 +26,7 @@ from behave.model import Table
 
 # TODO: We aren't consistently using typed parameters in step implementations - we should be.
 from grakn.api.concept.type.attribute_type import AttributeType
-from grakn.api.transaction import GraknTransaction
+from grakn.api.transaction import TransactionType
 from grakn.common.label import Label
 
 
@@ -117,8 +117,8 @@ register_type(ValueType=parse_value_type)
 
 
 @parse.with_pattern("read|write")
-def parse_transaction_type(value: str) -> GraknTransaction.Type:
-    return GraknTransaction.Type.READ if value == "read" else GraknTransaction.Type.WRITE
+def parse_transaction_type(value: str) -> TransactionType:
+    return TransactionType.READ if value == "read" else TransactionType.WRITE
 
 
 register_type(TransactionType=parse_transaction_type)

--- a/tests/behaviour/connection/session/session_steps.py
+++ b/tests/behaviour/connection/session/session_steps.py
@@ -24,13 +24,13 @@ from typing import List
 from behave import *
 from hamcrest import *
 
-from grakn.api.session import GraknSession
+from grakn.api.session import SessionType
 from tests.behaviour.config.parameters import parse_bool, parse_list
 from tests.behaviour.context import Context
 
 
-SCHEMA = GraknSession.Type.SCHEMA
-DATA = GraknSession.Type.DATA
+SCHEMA = SessionType.SCHEMA
+DATA = SessionType.DATA
 
 
 def open_sessions_for_databases(context: Context, names: list, session_type=DATA):

--- a/tests/behaviour/connection/transaction/transaction_steps.py
+++ b/tests/behaviour/connection/transaction/transaction_steps.py
@@ -24,13 +24,13 @@ from typing import Callable, List
 from behave import *
 from hamcrest import *
 
-from grakn.api.transaction import GraknTransaction
+from grakn.api.transaction import GraknTransaction, TransactionType
 from grakn.common.exception import GraknClientException
 from tests.behaviour.config.parameters import parse_transaction_type, parse_list, parse_bool
 from tests.behaviour.context import Context
 
 
-def for_each_session_open_transaction_of_type(context: Context, transaction_types: List[GraknTransaction.Type]):
+def for_each_session_open_transaction_of_type(context: Context, transaction_types: List[TransactionType]):
     for session in context.sessions:
         transactions = []
         for transaction_type in transaction_types:
@@ -54,7 +54,7 @@ def step_impl(context: Context):
     for_each_session_open_transaction_of_type(context, transaction_types)
 
 
-def open_transactions_of_type_throws_exception(context: Context, transaction_types: List[GraknTransaction.Type]):
+def open_transactions_of_type_throws_exception(context: Context, transaction_types: List[TransactionType]):
     for session in context.sessions:
         for transaction_type in transaction_types:
             try:

--- a/tests/deployment/test.py
+++ b/tests/deployment/test.py
@@ -23,10 +23,10 @@ from unittest import TestCase
 from grakn.client import *
 
 
-SCHEMA = GraknSession.Type.SCHEMA
-DATA = GraknSession.Type.DATA
-READ = GraknTransaction.Type.READ
-WRITE = GraknTransaction.Type.WRITE
+SCHEMA = SessionType.SCHEMA
+DATA = SessionType.DATA
+READ = TransactionType.READ
+WRITE = TransactionType.WRITE
 
 
 class TestClientPython(TestCase):

--- a/tests/integration/test_cluster_failover.py
+++ b/tests/integration/test_cluster_failover.py
@@ -25,9 +25,9 @@ from grakn.api.database import ClusterDatabaseManager
 from grakn.client import *
 
 
-SCHEMA = GraknSession.Type.SCHEMA
-WRITE = GraknTransaction.Type.WRITE
-READ = GraknTransaction.Type.READ
+SCHEMA = SessionType.SCHEMA
+WRITE = TransactionType.WRITE
+READ = TransactionType.READ
 
 
 class TestClusterFailover(TestCase):

--- a/tests/integration/test_concurrent.py
+++ b/tests/integration/test_concurrent.py
@@ -26,8 +26,8 @@ from grakn.client import *
 
 
 GRAKN = "grakn"
-DATA = GraknSession.Type.DATA
-WRITE = GraknTransaction.Type.WRITE
+DATA = SessionType.DATA
+WRITE = TransactionType.WRITE
 
 
 class TestConcurrent(TestCase):


### PR DESCRIPTION
## What is the goal of this PR?

While aligning Client Python with Client Java, we introduced `GraknTransaction.Type` and `GraknSession.Type`. But in Python these proved cumbersome to type out. So we reverted them to `SessionType` and `TransactionType`.

## What are the changes implemented in this PR?

Shorten enum names to SessionType, TransactionType
