### PR TITLE
Implement explanations

### DIFF
--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,7 +27,7 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "136d9e134a59ab4207d9d45de241997918e0f798",
+        commit = "a36868f1e8a34188eb371dee329ed499399cb40f",
     )
 
 def graknlabs_grakn_cluster_artifacts():

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -37,5 +37,5 @@ def graknlabs_grakn_cluster_artifacts():
         artifact_name = "grakn-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "c361e8e4b3f1e14aa8fde4c284ebf2cb2113b99f"
+        commit = "f08e4d9e194ee7e1806995377c8b0a7bd56903ec"
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -30,7 +30,7 @@ def graknlabs_common():
     git_repository(
         name = "graknlabs_common",
         remote = "https://github.com/graknlabs/common",
-        tag = "2.0.0-alpha-9" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
+        tag = "2.0.0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
     )
 
 def graknlabs_behaviour():

--- a/grakn/api/answer/concept_map.py
+++ b/grakn/api/answer/concept_map.py
@@ -17,7 +17,7 @@
 # under the License.
 #
 from abc import ABC, abstractmethod
-from typing import Mapping, Iterable
+from typing import Mapping, Iterable, Tuple
 
 from grakn.api.concept.concept import Concept
 
@@ -35,3 +35,43 @@ class ConceptMap(ABC):
     @abstractmethod
     def get(self, variable: str) -> Concept:
         pass
+
+    @abstractmethod
+    def explainables(self) -> "ConceptMap.Explainables":
+        pass
+
+    class Explainables(ABC):
+
+        @abstractmethod
+        def relation(self, variable: str) -> "ConceptMap.Explainable":
+            pass
+
+        @abstractmethod
+        def attribute(self, variable: str) -> "ConceptMap.Explainable":
+            pass
+
+        @abstractmethod
+        def ownership(self, owner: str, attribute: str) -> "ConceptMap.Explainable":
+            pass
+
+        @abstractmethod
+        def relations(self) -> Mapping[str, "ConceptMap.Explainable"]:
+            pass
+
+        @abstractmethod
+        def attributes(self) -> Mapping[str, "ConceptMap.Explainable"]:
+            pass
+
+        @abstractmethod
+        def ownerships(self) -> Mapping[Tuple[str, str], "ConceptMap.Explainable"]:
+            pass
+
+    class Explainable(ABC):
+
+        @abstractmethod
+        def conjunction(self) -> str:
+            pass
+
+        @abstractmethod
+        def explainable_id(self) -> int:
+            pass

--- a/grakn/api/logic/explanation.py
+++ b/grakn/api/logic/explanation.py
@@ -16,24 +16,27 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+from abc import ABC, abstractmethod
+from typing import Mapping, Set
 
-## To install all dependencies, run: pip3 install -r requirements_dev.txt
-
-
-## Configuration options
-
-# Allow importing of snapshots
---extra-index-url https://repo.grakn.ai/repository/pypi-snapshot/simple
+from grakn.api.answer.concept_map import ConceptMap
+from grakn.api.logic.rule import Rule
 
 
-## Dependencies
+class Explanation(ABC):
 
-grakn-protocol==0.0.0-38d442fdb2f1a5f2f9707c3ee5625fe09efc3a97
-grpcio==1.36.1
-protobuf==3.15.5
+    @abstractmethod
+    def rule(self) -> Rule:
+        pass
 
+    @abstractmethod
+    def then_answer(self) -> ConceptMap:
+        pass
 
-# Dev dependencies (not required to use the grakn-client package, but necessary for its development)
+    @abstractmethod
+    def when_answer(self) -> ConceptMap:
+        pass
 
-behave==1.2.6
-PyHamcrest==2.0.2
+    @abstractmethod
+    def variable_mapping(self) -> Mapping[str, Set[str]]:
+        pass

--- a/grakn/api/logic/explanation.py
+++ b/grakn/api/logic/explanation.py
@@ -30,11 +30,11 @@ class Explanation(ABC):
         pass
 
     @abstractmethod
-    def then_answer(self) -> ConceptMap:
+    def conclusion(self) -> ConceptMap:
         pass
 
     @abstractmethod
-    def when_answer(self) -> ConceptMap:
+    def condition(self) -> ConceptMap:
         pass
 
     @abstractmethod

--- a/grakn/api/query/query_manager.py
+++ b/grakn/api/query/query_manager.py
@@ -23,6 +23,7 @@ from grakn.api.answer.concept_map import ConceptMap
 from grakn.api.answer.concept_map_group import ConceptMapGroup
 from grakn.api.answer.numeric import Numeric
 from grakn.api.answer.numeric_group import NumericGroup
+from grakn.api.logic.explanation import Explanation
 from grakn.api.options import GraknOptions
 from grakn.api.query.future import QueryFuture
 
@@ -55,6 +56,10 @@ class QueryManager(ABC):
 
     @abstractmethod
     def update(self, query: str, options: GraknOptions = None) -> Iterator[ConceptMap]:
+        pass
+
+    @abstractmethod
+    def explain(self, explainable: ConceptMap.Explainable, options: GraknOptions = None) -> Iterator[Explanation]:
         pass
 
     @abstractmethod

--- a/grakn/common/exception.py
+++ b/grakn/common/exception.py
@@ -102,7 +102,9 @@ MISSING_LABEL = ConceptErrorMessage(4, "Label cannot be null or empty.")
 BAD_ENCODING = ConceptErrorMessage(5, "The encoding '%s' was not recognised.")
 BAD_VALUE_TYPE = ConceptErrorMessage(6, "The value type '%s' was not recognised.")
 BAD_ATTRIBUTE_VALUE = ConceptErrorMessage(7, "The attribute value '%s' was not recognised.")
-GET_HAS_WITH_MULTIPLE_FILTERS = ConceptErrorMessage(8, "Only one filter can be applied at a time to get_has. The possible filters are: [attribute_type, attribute_types, only_key]")
+NONEXISTENT_EXPLAINABLE_CONCEPT = ConceptErrorMessage(8, "The concept identified by '%s' is not explainable.")
+NONEXISTENT_EXPLAINABLE_OWNERSHIP = ConceptErrorMessage(9, "The ownership by owner '%s' of attribute '%s' is not explainable.")
+GET_HAS_WITH_MULTIPLE_FILTERS = ConceptErrorMessage(10, "Only one filter can be applied at a time to get_has. The possible filters are: [attribute_type, attribute_types, only_key]")
 
 
 class QueryErrorMessage(ErrorMessage):

--- a/grakn/common/rpc/request_builder.py
+++ b/grakn/common/rpc/request_builder.py
@@ -229,6 +229,14 @@ def query_manager_update_req(query: str, options: options_proto.Options):
     return query_manager_req(query_mgr_req, options)
 
 
+def query_manager_explain_req(explainable_id: int, options: options_proto.Options):
+    query_mgr_req = query_proto.QueryManager.Req()
+    explain_req = query_proto.QueryManager.Explain.Req()
+    explain_req.explainable_id = explainable_id
+    query_mgr_req.explain_req.CopyFrom(explain_req)
+    return query_manager_req(query_mgr_req, options)
+
+
 # ConceptManager
 
 def concept_manager_req(concept_mgr_req: concept_proto.ConceptManager.Req):

--- a/grakn/concept/answer/concept_map.py
+++ b/grakn/concept/answer/concept_map.py
@@ -17,27 +17,44 @@
 # under the License.
 #
 
-from typing import Mapping
+from typing import Mapping, Dict, Tuple
 
 import grakn_protocol.common.answer_pb2 as answer_proto
 
 from grakn.api.answer.concept_map import ConceptMap
 from grakn.api.concept.concept import Concept
-from grakn.common.exception import GraknClientException, VARIABLE_DOES_NOT_EXIST
+from grakn.common.exception import GraknClientException, VARIABLE_DOES_NOT_EXIST, NONEXISTENT_EXPLAINABLE_CONCEPT, \
+    NONEXISTENT_EXPLAINABLE_OWNERSHIP
 from grakn.concept.proto import concept_proto_reader
+
+
+def _explainables_of(explainables: answer_proto.Explainables):
+    relations: Dict[str, ConceptMap.Explainable] = {}
+    for var in explainables.explainable_relations:
+        explainable = explainables.explainable_relations[var]
+        relations[var] = _ConceptMap.Explainable.of(explainable)
+    attributes: Dict[str, ConceptMap.Explainable] = {}
+    for var in explainables.explainable_attributes:
+        explainable = explainables.explainable_attributes[var]
+        attributes[var] = _ConceptMap.Explainable.of(explainable)
+    ownerships: Dict[Tuple[str, str], ConceptMap.Explainable] = {}
+    for ownership in explainables.explainable_ownerships:
+        ownerships[(ownership.owner, ownership.attribute)] = _ConceptMap.Explainable.of(ownership.explainable)
+    return _ConceptMap.Explainables(relations, attributes, ownerships)
 
 
 class _ConceptMap(ConceptMap):
 
-    def __init__(self, mapping: Mapping[str, Concept]):
+    def __init__(self, mapping: Mapping[str, Concept], explainables: ConceptMap.Explainables = None):
         self._map = mapping
+        self._explainables = explainables
 
     @staticmethod
-    def of(concept_map_proto: answer_proto.ConceptMap) -> "_ConceptMap":
+    def of(res: answer_proto.ConceptMap) -> "_ConceptMap":
         variable_map = {}
-        for res_var in concept_map_proto.map:
-            variable_map[res_var] = concept_proto_reader.concept(concept_map_proto.map[res_var])
-        return _ConceptMap(variable_map)
+        for res_var in res.map:
+            variable_map[res_var] = concept_proto_reader.concept(res.map[res_var])
+        return _ConceptMap(variable_map, _explainables_of(res.explainables))
 
     def map(self):
         return self._map
@@ -51,6 +68,9 @@ class _ConceptMap(ConceptMap):
             raise GraknClientException.of(VARIABLE_DOES_NOT_EXIST, variable)
         return concept
 
+    def explainables(self) -> ConceptMap.Explainables:
+        return self._explainables
+
     def __str__(self):
         return "".join(map(lambda var: "[" + var + "/" + str(self._map[var]) + "]", sorted(self._map.keys())))
 
@@ -63,3 +83,73 @@ class _ConceptMap(ConceptMap):
 
     def __hash__(self):
         return hash(self._map)
+
+    class Explainables(ConceptMap.Explainables):
+
+        def __init__(self, relations: Mapping[str, ConceptMap.Explainable] = None, attributes: Mapping[str, ConceptMap.Explainable] = None, ownerships: Mapping[Tuple[str, str], ConceptMap.Explainable] = None):
+            self._relations = relations
+            self._attributes = attributes
+            self._ownerships = ownerships
+
+        def relation(self, variable: str) -> "ConceptMap.Explainable":
+            explainable = self._relations.get(variable)
+            if not explainable:
+                raise GraknClientException.of(NONEXISTENT_EXPLAINABLE_CONCEPT, variable)
+            return explainable
+
+        def attribute(self, variable: str) -> "ConceptMap.Explainable":
+            explainable = self._attributes.get(variable)
+            if not explainable:
+                raise GraknClientException.of(NONEXISTENT_EXPLAINABLE_CONCEPT, variable)
+            return explainable
+
+        def ownership(self, owner: str, attribute: str) -> "ConceptMap.Explainable":
+            explainable = self._ownerships.get((owner, attribute))
+            if not explainable:
+                raise GraknClientException.of(NONEXISTENT_EXPLAINABLE_OWNERSHIP, (owner, attribute))
+            return explainable
+
+        def relations(self) -> Mapping[str, "ConceptMap.Explainable"]:
+            return self._relations
+
+        def attributes(self) -> Mapping[str, "ConceptMap.Explainable"]:
+            return self._attributes
+
+        def ownerships(self) -> Mapping[Tuple[str, str], "ConceptMap.Explainable"]:
+            return self._ownerships
+
+        def __eq__(self, other):
+            if other is self:
+                return True
+            if not other or type(other) != type(self):
+                return False
+            return self._relations == other._relations and self._attributes == other._attributes and self._ownerships == other._ownerships
+
+        def __hash__(self):
+            return hash((self._relations, self._attributes, self._ownerships))
+
+    class Explainable(ConceptMap.Explainable):
+
+        def __init__(self, conjunction: str, explainable_id: int):
+            self._conjunction = conjunction
+            self._explainable_id = explainable_id
+
+        @staticmethod
+        def of(explainable: answer_proto.Explainable):
+            return _ConceptMap.Explainable(explainable.conjunction, explainable.id)
+
+        def conjunction(self) -> str:
+            return self._conjunction
+
+        def explainable_id(self) -> int:
+            return self._explainable_id
+
+        def __eq__(self, other):
+            if other is self:
+                return True
+            if not other or type(other) != type(self):
+                return False
+            return self._explainable_id
+
+        def __hash__(self):
+            return hash(self._explainable_id)

--- a/grakn/concept/thing/thing.py
+++ b/grakn/concept/thing/thing.py
@@ -45,7 +45,7 @@ class _Thing(Thing, _Concept, ABC):
         return self._iid
 
     def __str__(self):
-        return type(self).__name__ + "[iid:" + self.get_iid() + "]"
+        return "%s[%s:%s]" % (type(self).__name__, self.get_type().get_label(), self.get_iid())
 
     def __eq__(self, other):
         if other is self:

--- a/grakn/logic/explanation.py
+++ b/grakn/logic/explanation.py
@@ -27,7 +27,7 @@ from grakn.concept.answer.concept_map import _ConceptMap
 from grakn.logic.rule import _Rule
 
 
-def _var_mapping_of(var_mapping: Mapping[str, logic_proto.Explanation.VarsList]):
+def _var_mapping_of(var_mapping: Mapping[str, logic_proto.Explanation.VarList]):
     mapping = {}
     for from_ in var_mapping:
         tos = var_mapping[from_]
@@ -37,16 +37,16 @@ def _var_mapping_of(var_mapping: Mapping[str, logic_proto.Explanation.VarsList])
 
 class _Explanation(Explanation):
 
-    def __init__(self, rule: Rule, variable_mapping: Mapping[str, Set[str]], then_answer: ConceptMap, when_answer: ConceptMap):
+    def __init__(self, rule: Rule, variable_mapping: Mapping[str, Set[str]], conclusion: ConceptMap, condition: ConceptMap):
         self._rule = rule
         self._variable_mapping = variable_mapping
-        self._then_answer = then_answer
-        self._when_answer = when_answer
+        self._conclusion = conclusion
+        self._condition = condition
 
     @staticmethod
     def of(explanation: logic_proto.Explanation):
         return _Explanation(_Rule.of(explanation.rule), _var_mapping_of(explanation.var_mapping),
-                            _ConceptMap.of(explanation.then_answer), _ConceptMap.of(explanation.when_answer))
+                            _ConceptMap.of(explanation.conclusion), _ConceptMap.of(explanation.condition))
 
     def rule(self) -> Rule:
         return self._rule
@@ -54,21 +54,21 @@ class _Explanation(Explanation):
     def variable_mapping(self) -> Mapping[str, Set[str]]:
         return self._variable_mapping
 
-    def then_answer(self) -> ConceptMap:
-        return self._then_answer
+    def conclusion(self) -> ConceptMap:
+        return self._conclusion
 
-    def when_answer(self) -> ConceptMap:
-        return self._when_answer
+    def condition(self) -> ConceptMap:
+        return self._condition
 
     def __str__(self):
-        return "Explanation[rule: %s, variable_mapping: %s, then_answer: %s, when_answer: %s]" % (self._rule, self._variable_mapping, self._then_answer, self._when_answer)
+        return "Explanation[rule: %s, variable_mapping: %s, then_answer: %s, when_answer: %s]" % (self._rule, self._variable_mapping, self._conclusion, self._condition)
 
     def __eq__(self, other):
         if other is self:
             return True
         if not other or type(self) != type(other):
             return False
-        return self._rule == other._rule and self._variable_mapping == other._variable_mapping and self._then_answer == other._then_answer and self._when_answer == other._when_answer
+        return self._rule == other._rule and self._variable_mapping == other._variable_mapping and self._conclusion == other._conclusion and self._condition == other._condition
 
     def __hash__(self):
-        return hash((self._rule, self._variable_mapping, self._then_answer, self._when_answer))
+        return hash((self._rule, self._variable_mapping, self._conclusion, self._condition))

--- a/grakn/logic/explanation.py
+++ b/grakn/logic/explanation.py
@@ -1,0 +1,74 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+from typing import Mapping, Set
+
+import grakn_protocol.common.logic_pb2 as logic_proto
+
+from grakn.api.answer.concept_map import ConceptMap
+from grakn.api.logic.explanation import Explanation
+from grakn.api.logic.rule import Rule
+from grakn.concept.answer.concept_map import _ConceptMap
+from grakn.logic.rule import _Rule
+
+
+def _var_mapping_of(var_mapping: Mapping[str, logic_proto.Explanation.VarsList]):
+    mapping = {}
+    for from_ in var_mapping:
+        tos = var_mapping[from_]
+        mapping[from_] = set(tos.vars_list)
+    return mapping
+
+
+class _Explanation(Explanation):
+
+    def __init__(self, rule: Rule, variable_mapping: Mapping[str, Set[str]], then_answer: ConceptMap, when_answer: ConceptMap):
+        self._rule = rule
+        self._variable_mapping = variable_mapping
+        self._then_answer = then_answer
+        self._when_answer = when_answer
+
+    @staticmethod
+    def of(explanation: logic_proto.Explanation):
+        return _Explanation(_Rule.of(explanation.rule), _var_mapping_of(explanation.var_mapping),
+                            _ConceptMap.of(explanation.then_answer), _ConceptMap.of(explanation.when_answer))
+
+    def rule(self) -> Rule:
+        return self._rule
+
+    def variable_mapping(self) -> Mapping[str, Set[str]]:
+        return self._variable_mapping
+
+    def then_answer(self) -> ConceptMap:
+        return self._then_answer
+
+    def when_answer(self) -> ConceptMap:
+        return self._when_answer
+
+    def __str__(self):
+        return "Explanation[rule: %s, variable_mapping: %s, then_answer: %s, when_answer: %s]" % (self._rule, self._variable_mapping, self._then_answer, self._when_answer)
+
+    def __eq__(self, other):
+        if other is self:
+            return True
+        if not other or type(self) != type(other):
+            return False
+        return self._rule == other._rule and self._variable_mapping == other._variable_mapping and self._then_answer == other._then_answer and self._when_answer == other._when_answer
+
+    def __hash__(self):
+        return hash((self._rule, self._variable_mapping, self._then_answer, self._when_answer))

--- a/grakn/logic/explanation.py
+++ b/grakn/logic/explanation.py
@@ -31,7 +31,7 @@ def _var_mapping_of(var_mapping: Mapping[str, logic_proto.Explanation.VarsList])
     mapping = {}
     for from_ in var_mapping:
         tos = var_mapping[from_]
-        mapping[from_] = set(tos.vars_list)
+        mapping[from_] = set(tos.vars)
     return mapping
 
 

--- a/grakn/query/query_manager.py
+++ b/grakn/query/query_manager.py
@@ -17,19 +17,27 @@
 # under the License.
 #
 
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Union, Iterator
 
 import grakn_protocol.common.transaction_pb2 as transaction_proto
 
+from grakn.api.answer.concept_map import ConceptMap
+from grakn.api.answer.concept_map_group import ConceptMapGroup
+from grakn.api.answer.numeric import Numeric
+from grakn.api.answer.numeric_group import NumericGroup
+from grakn.api.logic.explanation import Explanation
 from grakn.api.options import GraknOptions
+from grakn.api.query.future import QueryFuture
 from grakn.api.query.query_manager import QueryManager
 from grakn.common.rpc.request_builder import query_manager_match_req, query_manager_match_aggregate_req, \
     query_manager_match_group_req, query_manager_match_group_aggregate_req, query_manager_insert_req, \
-    query_manager_delete_req, query_manager_update_req, query_manager_define_req, query_manager_undefine_req
+    query_manager_delete_req, query_manager_update_req, query_manager_define_req, query_manager_undefine_req, \
+    query_manager_explain_req
 from grakn.concept.answer.concept_map import _ConceptMap
 from grakn.concept.answer.concept_map_group import _ConceptMapGroup
 from grakn.concept.answer.numeric import _Numeric
 from grakn.concept.answer.numeric_group import _NumericGroup
+from grakn.logic.explanation import _Explanation
 
 if TYPE_CHECKING:
     from grakn.api.transaction import _GraknTransactionExtended, GraknTransaction
@@ -40,49 +48,54 @@ class _QueryManager(QueryManager):
     def __init__(self, transaction_ext: Union["_GraknTransactionExtended", "GraknTransaction"]):
         self._transaction_ext = transaction_ext
 
-    def match(self, query: str, options: GraknOptions = None):
+    def match(self, query: str, options: GraknOptions = None) -> Iterator[ConceptMap]:
         if not options:
             options = GraknOptions.core()
         return (_ConceptMap.of(cm) for rp in self.stream(query_manager_match_req(query, options.proto())) for cm in rp.match_res_part.answers)
 
-    def match_aggregate(self, query: str, options: GraknOptions = None):
+    def match_aggregate(self, query: str, options: GraknOptions = None) -> QueryFuture[Numeric]:
         if not options:
             options = GraknOptions.core()
         return self.query(query_manager_match_aggregate_req(query, options.proto())).map(lambda res: _Numeric.of(res.match_aggregate_res.answer))
 
-    def match_group(self, query: str, options: GraknOptions = None):
+    def match_group(self, query: str, options: GraknOptions = None) -> Iterator[ConceptMapGroup]:
         if not options:
             options = GraknOptions.core()
         return (_ConceptMapGroup.of(cmg) for rp in self.stream(query_manager_match_group_req(query, options.proto()))
                 for cmg in rp.match_group_res_part.answers)
 
-    def match_group_aggregate(self, query: str, options: GraknOptions = None):
+    def match_group_aggregate(self, query: str, options: GraknOptions = None) -> Iterator[NumericGroup]:
         if not options:
             options = GraknOptions.core()
         return (_NumericGroup.of(ng) for rp in self.stream(query_manager_match_group_aggregate_req(query, options.proto()))
                 for ng in rp.match_group_aggregate_res_part.answers)
 
-    def insert(self, query: str, options: GraknOptions = None):
+    def insert(self, query: str, options: GraknOptions = None) -> Iterator[ConceptMap]:
         if not options:
             options = GraknOptions.core()
         return (_ConceptMap.of(cm) for rp in self.stream(query_manager_insert_req(query, options.proto())) for cm in rp.insert_res_part.answers)
 
-    def delete(self, query: str, options: GraknOptions = None):
+    def delete(self, query: str, options: GraknOptions = None) -> QueryFuture:
         if not options:
             options = GraknOptions.core()
         return self.query_void(query_manager_delete_req(query, options.proto()))
 
-    def update(self, query: str, options: GraknOptions = None):
+    def update(self, query: str, options: GraknOptions = None) -> Iterator[ConceptMap]:
         if not options:
             options = GraknOptions.core()
         return (_ConceptMap.of(cm) for rp in self.stream(query_manager_update_req(query, options.proto())) for cm in rp.update_res_part.answers)
 
-    def define(self, query: str, options: GraknOptions = None):
+    def explain(self, explainable: ConceptMap.Explainable, options: GraknOptions = None) -> Iterator[Explanation]:
+        if not options:
+            options = GraknOptions.core()
+        return (_Explanation.of(ex) for rp in self.stream(query_manager_explain_req(explainable.explainable_id(), options)) for ex in rp.explain_res_part.explanations)
+
+    def define(self, query: str, options: GraknOptions = None) -> QueryFuture:
         if not options:
             options = GraknOptions.core()
         return self.query_void(query_manager_define_req(query, options.proto()))
 
-    def undefine(self, query: str, options: GraknOptions = None):
+    def undefine(self, query: str, options: GraknOptions = None) -> QueryFuture:
         if not options:
             options = GraknOptions.core()
         return self.query_void(query_manager_undefine_req(query, options.proto()))

--- a/grakn/query/query_manager.py
+++ b/grakn/query/query_manager.py
@@ -88,7 +88,7 @@ class _QueryManager(QueryManager):
     def explain(self, explainable: ConceptMap.Explainable, options: GraknOptions = None) -> Iterator[Explanation]:
         if not options:
             options = GraknOptions.core()
-        return (_Explanation.of(ex) for rp in self.stream(query_manager_explain_req(explainable.explainable_id(), options)) for ex in rp.explain_res_part.explanations)
+        return (_Explanation.of(ex) for rp in self.stream(query_manager_explain_req(explainable.explainable_id(), options.proto())) for ex in rp.explain_res_part.explanations)
 
     def define(self, query: str, options: GraknOptions = None) -> QueryFuture:
         if not options:

--- a/grakn/stream/bidirectional_stream.py
+++ b/grakn/stream/bidirectional_stream.py
@@ -29,7 +29,7 @@ from grakn.common.exception import GraknClientException, UNKNOWN_REQUEST_ID, TRA
 from grakn.common.rpc.stub import GraknCoreStub
 from grakn.stream.request_transmitter import RequestTransmitter
 from grakn.stream.response_collector import ResponseCollector
-from grakn.stream.response_iterator import ResponseIterator
+from grakn.stream.response_part_iterator import ResponsePartIterator
 
 T = TypeVar('T')
 
@@ -58,7 +58,7 @@ class BidirectionalStream:
         req.req_id = str(request_id)
         self._response_collector.new_queue(request_id)
         self._dispatcher.dispatch(req)
-        return ResponseIterator(request_id, self, self._dispatcher)
+        return ResponsePartIterator(request_id, self, self._dispatcher)
 
     def is_open(self) -> bool:
         return self._is_open.get()

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,6 @@
 ## Dependencies
 
 # IMPORTANT: Any changes to these dependencies should be copied to requirements_dev.txt.
-grakn-protocol==0.0.0-38d442fdb2f1a5f2f9707c3ee5625fe09efc3a97
+grakn-protocol==0.0.0-db450964d23303ab73a04c781db0dd0ef53fa869
 grpcio==1.36.1
 protobuf==3.15.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,6 @@
 ## Dependencies
 
 # IMPORTANT: Any changes to these dependencies should be copied to requirements_dev.txt.
-grakn-protocol==0.0.0-db450964d23303ab73a04c781db0dd0ef53fa869
+grakn-protocol==2.0.0
 grpcio==1.36.1
 protobuf==3.15.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,6 @@
 ## Dependencies
 
 # IMPORTANT: Any changes to these dependencies should be copied to requirements_dev.txt.
-grakn-protocol==0.0.0-32b98993572df3ae85ade58fd1c289bb45457bf2
+grakn-protocol==0.0.0-38d442fdb2f1a5f2f9707c3ee5625fe09efc3a97
 grpcio==1.36.1
 protobuf==3.15.5

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -28,7 +28,7 @@
 
 ## Dependencies
 
-grakn-protocol==0.0.0-38d442fdb2f1a5f2f9707c3ee5625fe09efc3a97
+grakn-protocol==0.0.0-db450964d23303ab73a04c781db0dd0ef53fa869
 grpcio==1.36.1
 protobuf==3.15.5
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -28,7 +28,7 @@
 
 ## Dependencies
 
-grakn-protocol==0.0.0-db450964d23303ab73a04c781db0dd0ef53fa869
+grakn-protocol==2.0.0
 grpcio==1.36.1
 protobuf==3.15.5
 

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -54,9 +54,9 @@ checkstyle_test(
 )
 
 py_test(
-    name = "test_concurrent",
+    name = "test_debug",
     srcs = [
-        "integration/test_concurrent.py",
+        "integration/test_debug.py",
     ],
     deps = [
         "//:client_python",

--- a/tests/integration/test_concurrent.py
+++ b/tests/integration/test_concurrent.py
@@ -26,16 +26,19 @@ from grakn.client import *
 
 
 GRAKN = "grakn"
+SCHEMA = SessionType.SCHEMA
 DATA = SessionType.DATA
 WRITE = TransactionType.WRITE
+READ = TransactionType.READ
 
 
 class TestConcurrent(TestCase):
 
     def setUp(self):
         with Grakn.core_client(Grakn.DEFAULT_ADDRESS) as client:
-            if not client.databases().contains(GRAKN):
-                client.databases().create(GRAKN)
+            if client.databases().contains(GRAKN):
+                client.databases().get(GRAKN).delete()
+            client.databases().create(GRAKN)
 
     def open_tx(self, session: GraknSession, *args):
         tx = session.transaction(WRITE)
@@ -51,6 +54,51 @@ class TestConcurrent(TestCase):
             pool.map(partial(self.open_tx, session), results)
             pool.close()
             pool.join()
+
+    def test_explanations(self):
+        with Grakn.core_client(Grakn.DEFAULT_ADDRESS) as client:
+            with client.session(GRAKN, SCHEMA) as session, session.transaction(WRITE) as tx:
+                schema = """
+                define
+                person sub entity, owns name, plays friendship:friend, plays marriage:husband, plays marriage:wife;
+                name sub attribute, value string;
+                friendship sub relation, relates friend;
+                marriage sub relation, relates husband, relates wife;
+                rule marriage-is-friendship: when {
+                    $x isa person; $y isa person; (husband: $x, wife: $y) isa marriage;
+                } then {
+                    (friend: $x, friend: $y) isa friendship;
+                };
+                rule everyone-is-friends: when {
+                    $x isa person; $y isa person; not { $x is $y; };
+                } then {
+                    (friend: $x, friend: $y) isa friendship;
+                };
+                """
+                tx.query().define(schema)
+                tx.commit()
+
+            with client.session(GRAKN, DATA) as session, session.transaction(WRITE) as tx:
+                data = """
+                insert
+                $x isa person, has name "Zack";
+                $y isa person, has name "Yasmin";
+                (husband: $x, wife: $y) isa marriage;
+                """
+                tx.query().insert(data)
+                tx.commit()
+
+            opts = GraknOptions.core()
+            opts.explain = True
+            with client.session(GRAKN, DATA) as session, session.transaction(READ, opts) as tx:
+                answers = list(tx.query().match("match (friend: $p1, friend: $p2) isa friendship; $p1 has name $na;"))
+                assert len(answers[0].explainables().relations()) == 1
+                assert len(answers[1].explainables().relations()) == 1
+                explanations = list(tx.query().explain(next(iter(answers[0].explainables().relations().values()))))
+                assert len(explanations) == 3
+                explanations2 = list(tx.query().explain(next(iter(answers[1].explainables().relations().values()))))
+                assert len(explanations2) == 3
+                print([str(e) for e in explanations])
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_debug.py
+++ b/tests/integration/test_debug.py
@@ -18,12 +18,9 @@
 #
 
 import unittest
-from functools import partial
-from multiprocessing.pool import ThreadPool
 from unittest import TestCase
 
 from grakn.client import *
-
 
 GRAKN = "grakn"
 SCHEMA = SessionType.SCHEMA
@@ -32,7 +29,7 @@ WRITE = TransactionType.WRITE
 READ = TransactionType.READ
 
 
-class TestConcurrent(TestCase):
+class TestDebug(TestCase):
 
     def setUp(self):
         with Grakn.core_client(Grakn.DEFAULT_ADDRESS) as client:
@@ -40,21 +37,11 @@ class TestConcurrent(TestCase):
                 client.databases().get(GRAKN).delete()
             client.databases().create(GRAKN)
 
-    def open_tx(self, session: GraknSession, *args):
-        tx = session.transaction(WRITE)
-        tx.close()
-        self.txs_closed += 1
-        print("Total txs closed: %d" % self.txs_closed)
+    # TODO: Write anything you want in this test for local debugging. A Grakn server should be running in the background
+    def test_debug(self):
+        pass
 
-    def test_open_many_transactions_in_parallel(self):
-        self.txs_closed = 0
-        with Grakn.core_client(Grakn.DEFAULT_ADDRESS) as client, client.session(GRAKN, DATA) as session:
-            pool = ThreadPool(8)
-            results = [None for _ in range(10)]
-            pool.map(partial(self.open_tx, session), results)
-            pool.close()
-            pool.join()
-
+    # TODO: This test should be migrated, ideally to BDD if possible
     def test_explanations(self):
         with Grakn.core_client(Grakn.DEFAULT_ADDRESS) as client:
             with client.session(GRAKN, SCHEMA) as session, session.transaction(WRITE) as tx:


### PR DESCRIPTION
## What is the goal of this PR?
Following https://github.com/graknlabs/grakn/pull/6271 and the corresponding protocol change in https://github.com/graknlabs/protocol/pull/131 we implement Explanations, Explainable concept maps, and the explain() query API, which allows users to stream Explanations on demand **note: explain query or transaction option must be set to `true`**

## What are the changes implemented in this PR?
* Implement `Explanation` objects, and extend `ConceptMap` to contain `Explainables`
* Add the `QueryManager.explain(Explainable)` API to retrieve all direct explanations (1-rule layer) 