### PR TITLE
Encode request IDs as bytes and make is_inferred a Local Thing method

### DIFF
--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -27,7 +27,7 @@ def graknlabs_grakn_core_artifacts():
         artifact_name = "grakn-core-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "a36868f1e8a34188eb371dee329ed499399cb40f",
+        commit = "922f9e50d05fd24187c5f020a8fc720722d49a60",
     )
 
 def graknlabs_grakn_cluster_artifacts():
@@ -37,5 +37,5 @@ def graknlabs_grakn_cluster_artifacts():
         artifact_name = "grakn-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "f08e4d9e194ee7e1806995377c8b0a7bd56903ec"
+        commit = "ff24c81c3ce821d25df802192db05d6084365161"
     )

--- a/grakn/api/concept/thing/thing.py
+++ b/grakn/api/concept/thing/thing.py
@@ -39,6 +39,10 @@ class Thing(Concept, ABC):
     def get_type(self) -> "ThingType":
         pass
 
+    @abstractmethod
+    def is_inferred(self) -> bool:
+        pass
+
     def is_thing(self) -> bool:
         return True
 
@@ -55,10 +59,6 @@ class RemoteThing(RemoteConcept, Thing, ABC):
 
     @abstractmethod
     def unset_has(self, attribute: "Attribute") -> None:
-        pass
-
-    @abstractmethod
-    def is_inferred(self) -> bool:
         pass
 
     @abstractmethod

--- a/grakn/cluster/client.py
+++ b/grakn/cluster/client.py
@@ -67,7 +67,7 @@ class _ClusterClient(GraknClusterClient):
     def session(self, database: str, session_type: SessionType, options=None) -> _ClusterSession:
         if not options:
             options = GraknOptions.cluster()
-        return self._session_any_replica(database, session_type, options) if options.read_any_replica else self._session_primary_replica(database, session_type, options)
+        return self._session_any_replica(database, session_type, options) if getattr(options, "read_any_replica", False) else self._session_primary_replica(database, session_type, options)
 
     def _session_primary_replica(self, database: str, session_type: SessionType, options=None) -> _ClusterSession:
         return _OpenSessionFailsafeTask(database, session_type, options, self).run_primary_replica()

--- a/grakn/cluster/session.py
+++ b/grakn/cluster/session.py
@@ -42,7 +42,7 @@ class _ClusterSession(GraknSession):
     def transaction(self, transaction_type: TransactionType, options: GraknClusterOptions = None) -> _CoreTransaction:
         if not options:
             options = GraknOptions.cluster()
-        return self._transaction_any_replica(transaction_type, options) if options.read_any_replica else self._transaction_primary_replica(transaction_type, options)
+        return self._transaction_any_replica(transaction_type, options) if getattr(options, "read_any_replica", False) else self._transaction_primary_replica(transaction_type, options)
 
     def _transaction_primary_replica(self, transaction_type: TransactionType, options: GraknClusterOptions) -> _CoreTransaction:
         return _TransactionFailsafeTask(self, transaction_type, options).run_primary_replica()

--- a/grakn/common/rpc/request_builder.py
+++ b/grakn/common/rpc/request_builder.py
@@ -583,12 +583,6 @@ def thing_req(req: concept_proto.Thing.Req, iid: str):
     return tx_req
 
 
-def thing_is_inferred_req(iid: str):
-    req = concept_proto.Thing.Req()
-    req.thing_is_inferred_req.CopyFrom(concept_proto.Thing.IsInferred.Req())
-    return thing_req(req, iid)
-
-
 def thing_get_has_req(iid: str, attribute_types: List[concept_proto.Type] = None, only_key: bool = False):
     if attribute_types and only_key:
         raise GraknClientException.of(GET_HAS_WITH_MULTIPLE_FILTERS)

--- a/grakn/common/rpc/request_builder.py
+++ b/grakn/common/rpc/request_builder.py
@@ -16,9 +16,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-import uuid
 from datetime import datetime
 from typing import List
+from uuid import UUID
 
 import grakn_protocol.cluster.cluster_database_pb2 as cluster_database_proto
 import grakn_protocol.cluster.cluster_server_pb2 as cluster_server_proto
@@ -114,9 +114,9 @@ def transaction_client_msg(reqs: List[transaction_proto.Transaction.Req]):
     return req
 
 
-def transaction_stream_req(req_id: uuid):
+def transaction_stream_req(req_id: UUID):
     req = transaction_proto.Transaction.Req()
-    req.req_id = str(req_id)
+    req.req_id = req_id.bytes
     stream_req = transaction_proto.Transaction.Stream.Req()
     req.stream_req.CopyFrom(stream_req)
     return req

--- a/grakn/concept/thing/attribute.py
+++ b/grakn/concept/thing/attribute.py
@@ -45,14 +45,14 @@ class _RemoteAttribute(RemoteAttribute, _RemoteThing, ABC):
 
 class _BooleanAttribute(BooleanAttribute, _Attribute):
 
-    def __init__(self, iid: str, type_: BooleanAttributeType, value: bool):
-        super(_BooleanAttribute, self).__init__(iid)
+    def __init__(self, iid: str, is_inferred: bool, type_: BooleanAttributeType, value: bool):
+        super(_BooleanAttribute, self).__init__(iid, is_inferred)
         self._type = type_
         self._value = value
 
     @staticmethod
     def of(thing_proto: concept_proto.Thing):
-        return _BooleanAttribute(concept_proto_reader.iid(thing_proto.iid), concept_proto_reader.attribute_type(thing_proto.type), thing_proto.value.boolean)
+        return _BooleanAttribute(concept_proto_reader.iid(thing_proto.iid), thing_proto.inferred, concept_proto_reader.attribute_type(thing_proto.type), thing_proto.value.boolean)
 
     def get_type(self) -> "BooleanAttributeType":
         return self._type
@@ -61,13 +61,13 @@ class _BooleanAttribute(BooleanAttribute, _Attribute):
         return self._value
 
     def as_remote(self, transaction):
-        return _RemoteBooleanAttribute(transaction, self.get_iid(), self.get_type(), self.get_value())
+        return _RemoteBooleanAttribute(transaction, self.get_iid(), self.is_inferred(), self.get_type(), self.get_value())
 
 
 class _RemoteBooleanAttribute(RemoteBooleanAttribute, _RemoteAttribute):
 
-    def __init__(self, transaction, iid: str, type_, value: bool):
-        super(_RemoteBooleanAttribute, self).__init__(transaction, iid)
+    def __init__(self, transaction, iid: str, is_inferred: bool, type_, value: bool):
+        super(_RemoteBooleanAttribute, self).__init__(transaction, iid, is_inferred)
         self._type = type_
         self._value = value
 
@@ -78,19 +78,19 @@ class _RemoteBooleanAttribute(RemoteBooleanAttribute, _RemoteAttribute):
         return self._value
 
     def as_remote(self, transaction):
-        return _RemoteBooleanAttribute(transaction, self.get_iid(), self.get_type(), self.get_value())
+        return _RemoteBooleanAttribute(transaction, self.get_iid(), self.is_inferred(), self.get_type(), self.get_value())
 
 
 class _LongAttribute(LongAttribute, _Attribute):
 
-    def __init__(self, iid: str, type_: LongAttributeType, value: int):
-        super(_LongAttribute, self).__init__(iid)
+    def __init__(self, iid: str, is_inferred: bool, type_: LongAttributeType, value: int):
+        super(_LongAttribute, self).__init__(iid, is_inferred)
         self._type = type_
         self._value = value
 
     @staticmethod
     def of(thing_proto: concept_proto.Thing):
-        return _LongAttribute(concept_proto_reader.iid(thing_proto.iid), concept_proto_reader.attribute_type(thing_proto.type), thing_proto.value.long)
+        return _LongAttribute(concept_proto_reader.iid(thing_proto.iid), thing_proto.inferred, concept_proto_reader.attribute_type(thing_proto.type), thing_proto.value.long)
 
     def get_type(self) -> "LongAttributeType":
         return self._type
@@ -99,13 +99,13 @@ class _LongAttribute(LongAttribute, _Attribute):
         return self._value
 
     def as_remote(self, transaction):
-        return _RemoteLongAttribute(transaction, self.get_iid(), self.get_type(), self.get_value())
+        return _RemoteLongAttribute(transaction, self.get_iid(), self.is_inferred(), self.get_type(), self.get_value())
 
 
 class _RemoteLongAttribute(RemoteLongAttribute, _RemoteAttribute):
 
-    def __init__(self, transaction, iid: str, type_, value: int):
-        super(_RemoteLongAttribute, self).__init__(transaction, iid)
+    def __init__(self, transaction, iid: str, is_inferred: bool, type_, value: int):
+        super(_RemoteLongAttribute, self).__init__(transaction, iid, is_inferred)
         self._type = type_
         self._value = value
 
@@ -116,19 +116,19 @@ class _RemoteLongAttribute(RemoteLongAttribute, _RemoteAttribute):
         return self._value
 
     def as_remote(self, transaction):
-        return _RemoteLongAttribute(transaction, self.get_iid(), self.get_type(), self.get_value())
+        return _RemoteLongAttribute(transaction, self.get_iid(), self.is_inferred(), self.get_type(), self.get_value())
 
 
 class _DoubleAttribute(DoubleAttribute, _Attribute):
 
-    def __init__(self, iid: str, type_: DoubleAttributeType, value: float):
-        super(_DoubleAttribute, self).__init__(iid)
+    def __init__(self, iid: str, is_inferred: bool, type_: DoubleAttributeType, value: float):
+        super(_DoubleAttribute, self).__init__(iid, is_inferred)
         self._type = type_
         self._value = value
 
     @staticmethod
     def of(thing_proto: concept_proto.Thing):
-        return _DoubleAttribute(concept_proto_reader.iid(thing_proto.iid), concept_proto_reader.attribute_type(thing_proto.type), thing_proto.value.double)
+        return _DoubleAttribute(concept_proto_reader.iid(thing_proto.iid), thing_proto.inferred, concept_proto_reader.attribute_type(thing_proto.type), thing_proto.value.double)
 
     def get_type(self) -> "DoubleAttributeType":
         return self._type
@@ -137,13 +137,13 @@ class _DoubleAttribute(DoubleAttribute, _Attribute):
         return self._value
 
     def as_remote(self, transaction):
-        return _RemoteDoubleAttribute(transaction, self.get_iid(), self.get_type(), self.get_value())
+        return _RemoteDoubleAttribute(transaction, self.get_iid(), self.is_inferred(), self.get_type(), self.get_value())
 
 
 class _RemoteDoubleAttribute(RemoteDoubleAttribute, _RemoteAttribute):
 
-    def __init__(self, transaction, iid: str, type_: DoubleAttributeType, value: float):
-        super(_RemoteDoubleAttribute, self).__init__(transaction, iid)
+    def __init__(self, transaction, iid: str, is_inferred: bool, type_: DoubleAttributeType, value: float):
+        super(_RemoteDoubleAttribute, self).__init__(transaction, iid, is_inferred)
         self._type = type_
         self._value = value
 
@@ -154,19 +154,19 @@ class _RemoteDoubleAttribute(RemoteDoubleAttribute, _RemoteAttribute):
         return self._value
 
     def as_remote(self, transaction):
-        return _RemoteDoubleAttribute(transaction, self.get_iid(), self.get_type(), self.get_value())
+        return _RemoteDoubleAttribute(transaction, self.get_iid(), self.is_inferred(), self.get_type(), self.get_value())
 
 
 class _StringAttribute(StringAttribute, _Attribute):
 
-    def __init__(self, iid: str, type_: StringAttributeType, value: str):
-        super(_StringAttribute, self).__init__(iid)
+    def __init__(self, iid: str, is_inferred: bool, type_: StringAttributeType, value: str):
+        super(_StringAttribute, self).__init__(iid, is_inferred)
         self._type = type_
         self._value = value
 
     @staticmethod
     def of(thing_proto: concept_proto.Thing):
-        return _StringAttribute(concept_proto_reader.iid(thing_proto.iid), concept_proto_reader.attribute_type(thing_proto.type), thing_proto.value.string)
+        return _StringAttribute(concept_proto_reader.iid(thing_proto.iid), thing_proto.inferred, concept_proto_reader.attribute_type(thing_proto.type), thing_proto.value.string)
 
     def get_type(self) -> "StringAttributeType":
         return self._type
@@ -175,13 +175,13 @@ class _StringAttribute(StringAttribute, _Attribute):
         return self._value
 
     def as_remote(self, transaction):
-        return _RemoteStringAttribute(transaction, self.get_iid(), self.get_type(), self.get_value())
+        return _RemoteStringAttribute(transaction, self.get_iid(), self.is_inferred(), self.get_type(), self.get_value())
 
 
 class _RemoteStringAttribute(RemoteStringAttribute, _RemoteAttribute):
 
-    def __init__(self, transaction, iid: str, type_: StringAttributeType, value: str):
-        super(_RemoteStringAttribute, self).__init__(transaction, iid)
+    def __init__(self, transaction, iid: str, is_inferred: bool, type_: StringAttributeType, value: str):
+        super(_RemoteStringAttribute, self).__init__(transaction, iid, is_inferred)
         self._type = type_
         self._value = value
 
@@ -192,19 +192,19 @@ class _RemoteStringAttribute(RemoteStringAttribute, _RemoteAttribute):
         return self._value
 
     def as_remote(self, transaction):
-        return _RemoteStringAttribute(transaction, self.get_iid(), self.get_type(), self.get_value())
+        return _RemoteStringAttribute(transaction, self.get_iid(), self.is_inferred(), self.get_type(), self.get_value())
 
 
 class _DateTimeAttribute(DateTimeAttribute, _Attribute):
 
-    def __init__(self, iid: str, type_: DateTimeAttributeType, value: datetime):
-        super(_DateTimeAttribute, self).__init__(iid)
+    def __init__(self, iid: str, is_inferred: bool, type_: DateTimeAttributeType, value: datetime):
+        super(_DateTimeAttribute, self).__init__(iid, is_inferred)
         self._type = type_
         self._value = value
 
     @staticmethod
     def of(thing_proto: concept_proto.Thing):
-        return _DateTimeAttribute(concept_proto_reader.iid(thing_proto.iid), concept_proto_reader.attribute_type(thing_proto.type), datetime.fromtimestamp(float(thing_proto.value.date_time) / 1000.0))
+        return _DateTimeAttribute(concept_proto_reader.iid(thing_proto.iid), thing_proto.inferred, concept_proto_reader.attribute_type(thing_proto.type), datetime.fromtimestamp(float(thing_proto.value.date_time) / 1000.0))
 
     def get_type(self) -> "DateTimeAttributeType":
         return self._type
@@ -213,13 +213,13 @@ class _DateTimeAttribute(DateTimeAttribute, _Attribute):
         return self._value
 
     def as_remote(self, transaction):
-        return _RemoteDateTimeAttribute(transaction, self.get_iid(), self.get_type(), self.get_value())
+        return _RemoteDateTimeAttribute(transaction, self.get_iid(), self.is_inferred(), self.get_type(), self.get_value())
 
 
 class _RemoteDateTimeAttribute(RemoteDateTimeAttribute, _RemoteAttribute):
 
-    def __init__(self, transaction, iid: str, type_: DateTimeAttributeType, value: datetime):
-        super(_RemoteDateTimeAttribute, self).__init__(transaction, iid)
+    def __init__(self, transaction, iid: str, is_inferred: bool, type_: DateTimeAttributeType, value: datetime):
+        super(_RemoteDateTimeAttribute, self).__init__(transaction, iid, is_inferred)
         self._type = type_
         self._value = value
 
@@ -230,4 +230,4 @@ class _RemoteDateTimeAttribute(RemoteDateTimeAttribute, _RemoteAttribute):
         return self._value
 
     def as_remote(self, transaction):
-        return _RemoteDateTimeAttribute(transaction, self.get_iid(), self.get_type(), self.get_value())
+        return _RemoteDateTimeAttribute(transaction, self.get_iid(), self.is_inferred(), self.get_type(), self.get_value())

--- a/grakn/concept/thing/entity.py
+++ b/grakn/concept/thing/entity.py
@@ -27,29 +27,29 @@ from grakn.concept.thing.thing import _Thing, _RemoteThing
 
 class _Entity(Entity, _Thing):
 
-    def __init__(self, iid: str, entity_type: EntityType):
-        super(_Entity, self).__init__(iid)
+    def __init__(self, iid: str, is_inferred: bool, entity_type: EntityType):
+        super(_Entity, self).__init__(iid, is_inferred)
         self._type = entity_type
 
     @staticmethod
     def of(thing_proto: concept_proto.Thing):
-        return _Entity(concept_proto_reader.iid(thing_proto.iid), concept_proto_reader.type_(thing_proto.type))
+        return _Entity(concept_proto_reader.iid(thing_proto.iid), thing_proto.inferred, concept_proto_reader.type_(thing_proto.type))
 
     def get_type(self) -> "EntityType":
         return self._type
 
     def as_remote(self, transaction):
-        return _RemoteEntity(transaction, self._iid, self.get_type())
+        return _RemoteEntity(transaction, self._iid, self.is_inferred(), self.get_type())
 
 
 class _RemoteEntity(_RemoteThing, RemoteEntity):
 
-    def __init__(self, transaction, iid: str, entity_type: EntityType):
-        super(_RemoteEntity, self).__init__(transaction, iid)
+    def __init__(self, transaction, iid: str, is_inferred: bool, entity_type: EntityType):
+        super(_RemoteEntity, self).__init__(transaction, iid, is_inferred)
         self._type = entity_type
 
     def as_remote(self, transaction):
-        return _RemoteEntity(transaction, self._iid, self.get_type())
+        return _RemoteEntity(transaction, self._iid, self.is_inferred(), self.get_type())
 
     def get_type(self) -> "EntityType":
         return self._type

--- a/grakn/concept/thing/relation.py
+++ b/grakn/concept/thing/relation.py
@@ -32,16 +32,16 @@ from grakn.concept.type.role_type import _RoleType
 
 class _Relation(Relation, _Thing):
 
-    def __init__(self, iid: str, relation_type: RelationType):
-        super(_Relation, self).__init__(iid)
+    def __init__(self, iid: str, is_inferred: bool, relation_type: RelationType):
+        super(_Relation, self).__init__(iid, is_inferred)
         self._type = relation_type
 
     @staticmethod
     def of(thing_proto: concept_proto.Thing):
-        return _Relation(concept_proto_reader.iid(thing_proto.iid), concept_proto_reader.type_(thing_proto.type))
+        return _Relation(concept_proto_reader.iid(thing_proto.iid), thing_proto.inferred, concept_proto_reader.type_(thing_proto.type))
 
     def as_remote(self, transaction):
-        return _RemoteRelation(transaction, self.get_iid(), self.get_type())
+        return _RemoteRelation(transaction, self.get_iid(), self.is_inferred(), self.get_type())
 
     def get_type(self) -> "RelationType":
         return self._type
@@ -49,12 +49,12 @@ class _Relation(Relation, _Thing):
 
 class _RemoteRelation(_RemoteThing, RemoteRelation):
 
-    def __init__(self, transaction, iid: str, relation_type: RelationType):
-        super(_RemoteRelation, self).__init__(transaction, iid)
+    def __init__(self, transaction, iid: str, is_inferred: bool, relation_type: RelationType):
+        super(_RemoteRelation, self).__init__(transaction, iid, is_inferred)
         self._type = relation_type
 
     def as_remote(self, transaction):
-        return _RemoteRelation(transaction, self.get_iid(), self.get_type())
+        return _RemoteRelation(transaction, self.get_iid(), self.is_inferred(), self.get_type())
 
     def get_type(self) -> "RelationType":
         return self._type

--- a/grakn/stream/bidirectional_stream.py
+++ b/grakn/stream/bidirectional_stream.py
@@ -45,7 +45,7 @@ class BidirectionalStream:
 
     def single(self, req: transaction_proto.Transaction.Req, batch: bool) -> "BidirectionalStream.Single[transaction_proto.Transaction.Res]":
         request_id = uuid4()
-        req.req_id = str(request_id)
+        req.req_id = request_id.bytes
         self._response_collector.new_queue(request_id)
         if batch:
             self._dispatcher.dispatch(req)
@@ -55,7 +55,7 @@ class BidirectionalStream:
 
     def stream(self, req: transaction_proto.Transaction.Req) -> Iterator[transaction_proto.Transaction.ResPart]:
         request_id = uuid4()
-        req.req_id = str(request_id)
+        req.req_id = request_id.bytes
         self._response_collector.new_queue(request_id)
         self._dispatcher.dispatch(req)
         return ResponsePartIterator(request_id, self, self._dispatcher)
@@ -91,7 +91,7 @@ class BidirectionalStream:
                 raise GraknClientException.of(ILLEGAL_ARGUMENT)
 
     def _collect(self, response: Union[transaction_proto.Transaction.Res, transaction_proto.Transaction.ResPart]):
-        request_id = UUID(response.req_id)
+        request_id = UUID(bytes=response.req_id)
         collector = self._response_collector.get(request_id)
         if collector:
             collector.put(response)

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,6 @@
 ## Dependencies
 
 # IMPORTANT: Any changes to these dependencies should be copied to requirements_dev.txt.
-grakn-protocol==0.0.0-85369fefff7a48951704929483df64be9b28959f
+grakn-protocol==0.0.0-39122114004684f270d78fa7da0e500f4c575e10
 grpcio==1.36.1
 protobuf==3.15.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,6 @@
 ## Dependencies
 
 # IMPORTANT: Any changes to these dependencies should be copied to requirements_dev.txt.
-grakn-protocol==2.0.0
+grakn-protocol==0.0.0-85369fefff7a48951704929483df64be9b28959f
 grpcio==1.36.1
 protobuf==3.15.5

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -28,7 +28,7 @@
 
 ## Dependencies
 
-grakn-protocol==0.0.0-85369fefff7a48951704929483df64be9b28959f
+grakn-protocol==0.0.0-39122114004684f270d78fa7da0e500f4c575e10
 grpcio==1.36.1
 protobuf==3.15.5
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -28,7 +28,7 @@
 
 ## Dependencies
 
-grakn-protocol==2.0.0
+grakn-protocol==0.0.0-85369fefff7a48951704929483df64be9b28959f
 grpcio==1.36.1
 protobuf==3.15.5
 

--- a/tests/behaviour/connection/transaction/transaction_steps.py
+++ b/tests/behaviour/connection/transaction/transaction_steps.py
@@ -24,6 +24,7 @@ from typing import Callable, List
 from behave import *
 from hamcrest import *
 
+from grakn.api.options import GraknOptions
 from grakn.api.transaction import GraknTransaction, TransactionType
 from grakn.common.exception import GraknClientException
 from tests.behaviour.config.parameters import parse_transaction_type, parse_list, parse_bool
@@ -34,7 +35,9 @@ def for_each_session_open_transaction_of_type(context: Context, transaction_type
     for session in context.sessions:
         transactions = []
         for transaction_type in transaction_types:
-            transaction = session.transaction(transaction_type)
+            opts = GraknOptions.core()
+            opts.infer = True
+            transaction = session.transaction(transaction_type, opts)
             transactions.append(transaction)
         context.sessions_to_transactions[session] = transactions
 


### PR DESCRIPTION
## What is the goal of this PR?

Previously the ID of a transaction request was stored as a string, which is an inefficient representation of a UUID. We've changed it to bytes.

Also, `is_inferred` is now a Local method on `Thing`.

## What are the changes implemented in this PR?

Store request IDs as bytes, not strings
Make isInferred a Local Thing method