### PR TITLE
Rename batch_size option to prefetch_size

### DIFF
--- a/grakn/api/options.py
+++ b/grakn/api/options.py
@@ -28,7 +28,7 @@ class GraknOptions:
         self.trace_inference: Optional[bool] = None
         self.explain: Optional[bool] = None
         self.parallel: Optional[bool] = None
-        self.batch_size: Optional[int] = None
+        self.prefetch_size: Optional[int] = None
         self.prefetch: Optional[bool] = None
         self.session_idle_timeout_millis: Optional[int] = None
         self.schema_lock_acquire_timeout_millis: Optional[int] = None
@@ -55,8 +55,8 @@ class GraknOptions:
             proto_options.explain = self.explain
         if self.parallel is not None:
             proto_options.parallel = self.parallel
-        if self.batch_size is not None:
-            proto_options.batch_size = self.batch_size
+        if self.prefetch_size is not None:
+            proto_options.prefetch_size = self.prefetch_size
         if self.prefetch is not None:
             proto_options.prefetch = self.prefetch
         if self.session_idle_timeout_millis is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,6 @@
 ## Dependencies
 
 # IMPORTANT: Any changes to these dependencies should be copied to requirements_dev.txt.
-grakn-protocol==2.0.1
+grakn-protocol==0.0.0-efac95a542c5f23b0ee881f7bd618224b0aa7d6c
 grpcio==1.36.1
 protobuf==3.15.5

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -28,7 +28,7 @@
 
 ## Dependencies
 
-grakn-protocol==0.0.0-39122114004684f270d78fa7da0e500f4c575e10
+grakn-protocol==0.0.0-efac95a542c5f23b0ee881f7bd618224b0aa7d6c
 grpcio==1.36.1
 protobuf==3.15.5
 


### PR DESCRIPTION
## What is the goal of this PR?

The option `batch_size` was misleading as we generally use 'batch' to refer to all of the messages sent by a peer (server or client) within a set time window (eg: 1ms). So we renamed it to `prefetch_size`.

## What are the changes implemented in this PR?

Rename batch_size option to prefetch_size
