### PR TITLE
Implement missing request builder implementation

### DIFF
--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -39,5 +39,5 @@ def vaticle_typedb_cluster_artifacts():
         artifact_name = "typedb-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "5a423f70c416d52f49ba541fe6b10b0ff2c89602"
+        commit = "f6d9eae58c83c165d932c0433a3a0d858e206fab"
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,6 @@
 
 ## Configuration options
 
-
 # Allow importing of snapshots
 --extra-index-url https://repo.vaticle.com/repository/pypi-snapshot/simple
 
@@ -32,6 +31,6 @@
 ## Dependencies
 
 # IMPORTANT: Any changes to these dependencies should be copied to requirements_dev.txt.
-typedb-protocol==2.4.0
+typedb-protocol==0.0.0-ec89440dadb449f223ad2c925b238aad06b80c81
 grpcio==1.38.0
 protobuf==3.15.5

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -30,7 +30,7 @@
 
 ## Dependencies
 
-typedb-protocol==2.4.0
+typedb-protocol==0.0.0-ec89440dadb449f223ad2c925b238aad06b80c81
 grpcio==1.38.0
 protobuf==3.15.5
 

--- a/typedb/common/rpc/request_builder.py
+++ b/typedb/common/rpc/request_builder.py
@@ -111,6 +111,11 @@ def cluster_user_password_req(username: str, password: str):
     req.password = password
     return req
 
+def cluster_user_token_req(username: str):
+    req = cluster_user_proto.ClusterUser.Token.Req()
+    req.username = username
+    return req
+
 def cluster_user_delete_req(username: str):
     req = cluster_user_proto.ClusterUser.Delete.Req()
     req.username = username


### PR DESCRIPTION
## What is the goal of this PR?

We've implemented the request builder for authentication token

## What are the changes implemented in this PR?

1. Implement request builder for authentication token
2. Update `protocol` in `requirements.txt` and `requirements_dev.txt`
3. Update `@vaticle_typedb_cluster_artifact`